### PR TITLE
Allow to export diagrams as SVGs

### DIFF
--- a/client/packages/uml-vscode-integration/extension/package.json
+++ b/client/packages/uml-vscode-integration/extension/package.json
@@ -66,6 +66,12 @@
         "enablement": "workspaceFolderCount > 0"
       },
       {
+        "command": "bigUML.exportAsSVG",
+        "title": "Export as SVG",
+        "category": "bigUML",
+        "enablement": "activeCustomEditorId == 'bigUML.diagramView'"
+      },
+      {
         "command": "bigUML.fit",
         "title": "Fit to Screen",
         "category": "bigUML",
@@ -180,6 +186,11 @@
         },
         {
           "command": "bigUML.center",
+          "group": "navigation",
+          "when": "activeCustomEditorId == 'bigUML.diagramView'"
+        },
+        {
+          "command": "bigUML.exportAsSVG",
           "group": "navigation",
           "when": "activeCustomEditorId == 'bigUML.diagramView'"
         }

--- a/client/packages/uml-vscode-integration/extension/src/vscode/command/default-commands.ts
+++ b/client/packages/uml-vscode-integration/extension/src/vscode/command/default-commands.ts
@@ -6,7 +6,7 @@
  *
  * SPDX-License-Identifier: MIT
  *********************************************************************************/
-import { CenterAction, FitToScreenAction, SelectAllAction } from '@eclipse-glsp/protocol';
+import { CenterAction, FitToScreenAction, RequestExportSvgAction, SelectAllAction } from '@eclipse-glsp/protocol';
 import * as vscode from 'vscode';
 import { UVGlspConnector } from '../../glsp/uv-glsp-connector';
 
@@ -35,11 +35,11 @@ export function configureDefaultCommands(context: CommandContext): void {
         }),
         vscode.commands.registerCommand(`${diagramPrefix}.show.umlPanel`, () => {
             vscode.commands.executeCommand('bigUML.panel.property-palette.focus');
-        })
-        /*
+        }),
         vscode.commands.registerCommand(`${diagramPrefix}.exportAsSVG`, () => {
             connector.sendActionToActiveClient(RequestExportSvgAction.create());
-        }),
+        })
+        /*
         vscode.commands.registerCommand(`${diagramPrefix}.layout`, () => {
             connector.sendActionToActiveClient(LayoutOperation.create([]));
         })

--- a/client/packages/uml-vscode-integration/webview/src/editor/app.ts
+++ b/client/packages/uml-vscode-integration/webview/src/editor/app.ts
@@ -11,11 +11,13 @@ import { createUmlDiagramContainer } from '@borkdominik-biguml/uml-glsp/lib';
 import '@eclipse-glsp/vscode-integration-webview/css/glsp-vscode.css';
 
 import { RequestPropertyPaletteAction, SetPropertyPaletteAction } from '@borkdominik-biguml/uml-common';
-import { GLSPStarter } from '@eclipse-glsp/vscode-integration-webview';
+import { GLSPStarter, GLSPVscodeDiagramServer } from '@eclipse-glsp/vscode-integration-webview';
 import { GLSPDiagramIdentifier } from '@eclipse-glsp/vscode-integration-webview/lib/diagram-identifer';
 import { GLSPVscodeDiagramWidget } from '@eclipse-glsp/vscode-integration-webview/lib/glsp-vscode-diagram-widget';
 import { Container } from 'inversify';
+// eslint-disable-next-line no-restricted-imports
 import { SprottyDiagramIdentifier } from 'sprotty-vscode-webview';
+import { UVDiagramServer } from './vscode/uv-diagram.server';
 import { UVDiagramWidget } from './vscode/uv-diagram.widget';
 
 class UVStarter extends GLSPStarter {
@@ -28,9 +30,13 @@ class UVStarter extends GLSPStarter {
     protected override addVscodeBindings(container: Container, diagramIdentifier: GLSPDiagramIdentifier): void {
         super.addVscodeBindings(container, diagramIdentifier);
         container.unbind(GLSPVscodeDiagramWidget);
+        container.unbind(GLSPVscodeDiagramServer);
 
         container.bind(UVDiagramWidget).toSelf().inSingletonScope();
         container.bind(GLSPVscodeDiagramWidget).toService(UVDiagramWidget);
+
+        container.bind(UVDiagramServer).toSelf().inSingletonScope();
+        container.bind(GLSPVscodeDiagramServer).toService(UVDiagramServer);
     }
 
     protected override get extensionActionKinds(): string[] {

--- a/client/packages/uml-vscode-integration/webview/src/editor/vscode/uv-diagram.server.ts
+++ b/client/packages/uml-vscode-integration/webview/src/editor/vscode/uv-diagram.server.ts
@@ -6,4 +6,12 @@
  *
  * SPDX-License-Identifier: MIT
  *********************************************************************************/
-export * from './edit-label.autocomplete';
+
+import { ExportSvgAction } from '@eclipse-glsp/protocol';
+import { GLSPVscodeDiagramServer } from '@eclipse-glsp/vscode-integration-webview';
+
+export class UVDiagramServer extends GLSPVscodeDiagramServer {
+    protected override handleExportSvgAction(action: ExportSvgAction): boolean {
+        return false;
+    }
+}


### PR DESCRIPTION
Close #115 

Command: `Export as SVG`
or
![image](https://github.com/borkdominik/bigUML/assets/13104167/9d51fda5-a399-4063-90e1-b1c249bc3b80)

Example
![diagram](https://github.com/borkdominik/bigUML/assets/13104167/573a862f-c291-4936-8901-89fc1373570d)
