### PR TITLE
Migrate use case / information flow / package diagram

### DIFF
--- a/client/packages/uml-glsp/src/uml/elements/actor/actor.element.ts
+++ b/client/packages/uml-glsp/src/uml/elements/actor/actor.element.ts
@@ -9,7 +9,6 @@
 
 import { UMLDiagramType } from '@borkdominik-biguml/uml-protocol';
 import { configureModelElement } from '@eclipse-glsp/client';
-import { DefaultTypes } from '@eclipse-glsp/protocol';
 import { interfaces } from 'inversify';
 import { QualifiedUtil } from '../../qualified.utils';
 import { NamedElement } from '../index';
@@ -21,10 +20,5 @@ export function registerActorElement(
     representation: UMLDiagramType
 ): void {
     configureModelElement(context, QualifiedUtil.typeId(representation, 'Actor'), NamedElement, ActorView);
-    configureModelElement(
-        context,
-        QualifiedUtil.representationTemplateTypeId(representation, DefaultTypes.NODE, 'GModel', 'STICKFIGURE'),
-        StickFigureNode,
-        StickFigureView
-    );
+    configureModelElement(context, QualifiedUtil.typeId(representation, 'ActorStickfigure'), StickFigureNode, StickFigureView);
 }

--- a/client/packages/uml-protocol/src/language/language.ts
+++ b/client/packages/uml-protocol/src/language/language.ts
@@ -26,7 +26,7 @@ export enum UMLDiagramType {
 }
 
 export namespace UMLDiagramTypeUtil {
-    export const supported: UMLDiagramType[] = [UMLDiagramType.CLASS, UMLDiagramType.USE_CASE];
+    export const supported: UMLDiagramType[] = [UMLDiagramType.CLASS, UMLDiagramType.INFORMATION_FLOW, UMLDiagramType.USE_CASE];
 
     export function parseString(diagramType: string): UMLDiagramType {
         return Object.values(UMLDiagramType).find(u => u.toUpperCase() === diagramType.toUpperCase()) ?? UMLDiagramType.NONE;

--- a/client/packages/uml-protocol/src/language/language.ts
+++ b/client/packages/uml-protocol/src/language/language.ts
@@ -26,7 +26,7 @@ export enum UMLDiagramType {
 }
 
 export namespace UMLDiagramTypeUtil {
-    export const supported: UMLDiagramType[] = [UMLDiagramType.CLASS];
+    export const supported: UMLDiagramType[] = [UMLDiagramType.CLASS, UMLDiagramType.USE_CASE];
 
     export function parseString(diagramType: string): UMLDiagramType {
         return Object.values(UMLDiagramType).find(u => u.toUpperCase() === diagramType.toUpperCase()) ?? UMLDiagramType.NONE;

--- a/client/packages/uml-protocol/src/language/language.ts
+++ b/client/packages/uml-protocol/src/language/language.ts
@@ -26,7 +26,12 @@ export enum UMLDiagramType {
 }
 
 export namespace UMLDiagramTypeUtil {
-    export const supported: UMLDiagramType[] = [UMLDiagramType.CLASS, UMLDiagramType.INFORMATION_FLOW, UMLDiagramType.USE_CASE];
+    export const supported: UMLDiagramType[] = [
+        UMLDiagramType.CLASS,
+        UMLDiagramType.INFORMATION_FLOW,
+        UMLDiagramType.PACKAGE,
+        UMLDiagramType.USE_CASE
+    ];
 
     export function parseString(diagramType: string): UMLDiagramType {
         return Object.values(UMLDiagramType).find(u => u.toUpperCase() === diagramType.toUpperCase()) ?? UMLDiagramType.NONE;

--- a/client/workspace/diagrams/class/class.uml
+++ b/client/workspace/diagrams/class/class.uml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="ASCII"?>
+<uml:Model xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:uml="http://www.eclipse.org/uml2/5.0.0/UML" xmi:id="_ePgIIO0zEe6ONuorAhNLBg">
+  <packagedElement xsi:type="uml:Package" xmi:id="_hCTDEO03Ee6l1tMMQqtO_Q" name="Package"/>
+  <packagedElement xsi:type="uml:Class" xmi:id="_epxCQO0zEe6ONuorAhNLBg" name="Class">
+    <ownedAttribute xmi:id="_fbL4IO0zEe6ONuorAhNLBg" name="Class" type="_e2z_wO0zEe6ONuorAhNLBg" association="_fbBgEO0zEe6ONuorAhNLBg">
+      <lowerValue xsi:type="uml:LiteralInteger" xmi:id="_fbNGQO0zEe6ONuorAhNLBg" value="1"/>
+      <upperValue xsi:type="uml:LiteralUnlimitedNatural" xmi:id="_fbNtUO0zEe6ONuorAhNLBg" value="1"/>
+    </ownedAttribute>
+  </packagedElement>
+  <packagedElement xsi:type="uml:Class" xmi:id="_e2z_wO0zEe6ONuorAhNLBg" name="Class">
+    <ownedAttribute xmi:id="_fbOUYO0zEe6ONuorAhNLBg" name="Class" type="_epxCQO0zEe6ONuorAhNLBg" association="_fbBgEO0zEe6ONuorAhNLBg">
+      <lowerValue xsi:type="uml:LiteralInteger" xmi:id="_fbOUYe0zEe6ONuorAhNLBg" value="1"/>
+      <upperValue xsi:type="uml:LiteralUnlimitedNatural" xmi:id="_fbO7cO0zEe6ONuorAhNLBg" value="1"/>
+    </ownedAttribute>
+  </packagedElement>
+  <packagedElement xsi:type="uml:Association" xmi:id="_fbBgEO0zEe6ONuorAhNLBg" memberEnd="_fbL4IO0zEe6ONuorAhNLBg _fbOUYO0zEe6ONuorAhNLBg"/>
+  <packagedElement xsi:type="uml:Package" xmi:id="_hSQxsO03Ee6l1tMMQqtO_Q" name="Package">
+    <packageImport xmi:id="_iQvzMO03Ee6l1tMMQqtO_Q" importedPackage="_hCTDEO03Ee6l1tMMQqtO_Q"/>
+  </packagedElement>
+</uml:Model>

--- a/client/workspace/diagrams/class/class.unotation
+++ b/client/workspace/diagrams/class/class.unotation
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="ASCII"?>
+<unotation:UMLDiagram xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:notation="http://www.eclipse.org/glsp/notation" xmlns:unotation="http://www.borkdominik.com/big-glsp/uml/unotation" xmi:id="_ePaoke0zEe6ONuorAhNLBg" diagramType="CLASS">
+  <semanticElement xmi:id="_ePgIIe0zEe6ONuorAhNLBg" elementId="_ePgIIO0zEe6ONuorAhNLBg"/>
+  <elements xsi:type="notation:Shape" xmi:id="_ep0FkO0zEe6ONuorAhNLBg">
+    <semanticElement xmi:id="_ep0Fke0zEe6ONuorAhNLBg" elementId="_epxCQO0zEe6ONuorAhNLBg"/>
+    <position xmi:id="_ep0Fku0zEe6ONuorAhNLBg" x="379.0" y="322.0"/>
+    <size xmi:id="_ep0Fk-0zEe6ONuorAhNLBg" width="60.0" height="45.0"/>
+  </elements>
+  <elements xsi:type="notation:Shape" xmi:id="_e22cAO0zEe6ONuorAhNLBg">
+    <semanticElement xmi:id="_e22cAe0zEe6ONuorAhNLBg" elementId="_e2z_wO0zEe6ONuorAhNLBg"/>
+    <position xmi:id="_e22cAu0zEe6ONuorAhNLBg" x="640.0" y="327.0"/>
+    <size xmi:id="_e22cA-0zEe6ONuorAhNLBg" width="60.0" height="45.0"/>
+  </elements>
+  <elements xsi:type="notation:Edge" xmi:id="_f8DwkO0zEe6ONuorAhNLBg">
+    <semanticElement xmi:id="_f8Dwke0zEe6ONuorAhNLBg" elementId="_fbBgEO0zEe6ONuorAhNLBg"/>
+  </elements>
+  <elements xsi:type="notation:Shape" xmi:id="_hCURMO03Ee6l1tMMQqtO_Q">
+    <semanticElement xmi:id="_hCURMe03Ee6l1tMMQqtO_Q" elementId="_hCTDEO03Ee6l1tMMQqtO_Q"/>
+    <position xmi:id="_jly6kO03Ee6l1tMMQqtO_Q" x="356.0" y="516.0"/>
+    <size xmi:id="_jlzhoO03Ee6l1tMMQqtO_Q" width="113.171875" height="45.0"/>
+  </elements>
+  <elements xsi:type="notation:Shape" xmi:id="_hSRYwO03Ee6l1tMMQqtO_Q">
+    <semanticElement xmi:id="_hSRYwe03Ee6l1tMMQqtO_Q" elementId="_hSQxsO03Ee6l1tMMQqtO_Q"/>
+    <position xmi:id="_kKI9wO03Ee6l1tMMQqtO_Q" x="698.0" y="508.0"/>
+    <size xmi:id="_kKI9we03Ee6l1tMMQqtO_Q" width="113.171875" height="45.0"/>
+  </elements>
+  <elements xsi:type="notation:Edge" xmi:id="_iQwaQO03Ee6l1tMMQqtO_Q">
+    <semanticElement xmi:id="_iQwaQe03Ee6l1tMMQqtO_Q" elementId="_iQvzMO03Ee6l1tMMQqtO_Q"/>
+  </elements>
+</unotation:UMLDiagram>

--- a/client/workspace/diagrams/information_flow/information_flow.uml
+++ b/client/workspace/diagrams/information_flow/information_flow.uml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="ASCII"?>
+<uml:Model xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:uml="http://www.eclipse.org/uml2/5.0.0/UML" xmi:id="_90nxMO0yEe6z1oa-gGLtSA">
+  <packagedElement xsi:type="uml:Actor" xmi:id="_gxI-cO0zEe6ONuorAhNLBg" name="Actor"/>
+  <packagedElement xsi:type="uml:Class" xmi:id="_hIr7wO0zEe6ONuorAhNLBg" name="Class"/>
+  <packagedElement xsi:type="uml:InformationFlow" xmi:id="_WQMSwe00Ee6OVo2Q_ZmZIQ" name=">>" informationSource="_gxI-cO0zEe6ONuorAhNLBg" informationTarget="_hIr7wO0zEe6ONuorAhNLBg"/>
+  <packagedElement xsi:type="uml:Class" xmi:id="_eta9wO00Ee6OVo2Q_ZmZIQ" name="Class"/>
+  <packagedElement xsi:type="uml:InformationFlow" xmi:id="_lmoRQO00Ee6N1LQzs4Gq-A" informationSource="_hIr7wO0zEe6ONuorAhNLBg" informationTarget="_eta9wO00Ee6OVo2Q_ZmZIQ"/>
+</uml:Model>

--- a/client/workspace/diagrams/information_flow/information_flow.unotation
+++ b/client/workspace/diagrams/information_flow/information_flow.unotation
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="ASCII"?>
+<unotation:UMLDiagram xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:notation="http://www.eclipse.org/glsp/notation" xmlns:unotation="http://www.borkdominik.com/big-glsp/uml/unotation" xmi:id="_90cLAe0yEe6z1oa-gGLtSA" diagramType="INFORMATION_FLOW">
+  <semanticElement xmi:id="_90oYQO0yEe6z1oa-gGLtSA" elementId="_90nxMO0yEe6z1oa-gGLtSA"/>
+  <elements xsi:type="notation:Shape" xmi:id="_gxJlgO0zEe6ONuorAhNLBg">
+    <semanticElement xmi:id="_gxJlge0zEe6ONuorAhNLBg" elementId="_gxI-cO0zEe6ONuorAhNLBg"/>
+    <position xmi:id="_gxJlgu0zEe6ONuorAhNLBg" x="298.0" y="266.0"/>
+    <size xmi:id="_gxJlg-0zEe6ONuorAhNLBg" width="60.0" height="45.0"/>
+  </elements>
+  <elements xsi:type="notation:Shape" xmi:id="_hIsi0O0zEe6ONuorAhNLBg">
+    <semanticElement xmi:id="_hIsi0e0zEe6ONuorAhNLBg" elementId="_hIr7wO0zEe6ONuorAhNLBg"/>
+    <position xmi:id="_hIsi0u0zEe6ONuorAhNLBg" x="638.0" y="291.0"/>
+    <size xmi:id="_hIsi0-0zEe6ONuorAhNLBg" width="60.0" height="45.0"/>
+  </elements>
+  <elements xsi:type="notation:Edge" xmi:id="_WQRyUO00Ee6OVo2Q_ZmZIQ">
+    <semanticElement xmi:id="_WQRyUe00Ee6OVo2Q_ZmZIQ" elementId="_WQMSwe00Ee6OVo2Q_ZmZIQ"/>
+  </elements>
+  <elements xsi:type="notation:Shape" xmi:id="_etbk0O00Ee6OVo2Q_ZmZIQ">
+    <semanticElement xmi:id="_etbk0e00Ee6OVo2Q_ZmZIQ" elementId="_eta9wO00Ee6OVo2Q_ZmZIQ"/>
+    <position xmi:id="_etbk0u00Ee6OVo2Q_ZmZIQ" x="640.0" y="466.0"/>
+    <size xmi:id="_etbk0-00Ee6OVo2Q_ZmZIQ" width="60.0" height="45.0"/>
+  </elements>
+  <elements xsi:type="notation:Edge" xmi:id="_lmr7oO00Ee6N1LQzs4Gq-A">
+    <semanticElement xmi:id="_lmr7oe00Ee6N1LQzs4Gq-A" elementId="_lmoRQO00Ee6N1LQzs4Gq-A"/>
+  </elements>
+</unotation:UMLDiagram>

--- a/client/workspace/diagrams/package/package.uml
+++ b/client/workspace/diagrams/package/package.uml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="ASCII"?>
+<uml:Model xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:uml="http://www.eclipse.org/uml2/5.0.0/UML" xmi:id="_E0bfIO03Ee6l1tMMQqtO_Q">
+  <packagedElement xsi:type="uml:Package" xmi:id="_FkpbIO03Ee6l1tMMQqtO_Q" name="Package">
+    <elementImport xmi:id="_GLbHQO03Ee6l1tMMQqtO_Q" alias="" importedElement="_FSaboO03Ee6l1tMMQqtO_Q"/>
+    <packageImport xmi:id="_NYKawO03Ee6l1tMMQqtO_Q" importedPackage="_MqzlgO03Ee6l1tMMQqtO_Q"/>
+    <packageMerge xmi:id="_S7HF8O03Ee6l1tMMQqtO_Q" mergedPackage="_SgrzwO03Ee6l1tMMQqtO_Q"/>
+  </packagedElement>
+  <packagedElement xsi:type="uml:Class" xmi:id="_FSaboO03Ee6l1tMMQqtO_Q" name="Class"/>
+  <packagedElement xsi:type="uml:Class" xmi:id="_LmvgcO03Ee6l1tMMQqtO_Q" name="Class"/>
+  <packagedElement xsi:type="uml:Package" xmi:id="_MqzlgO03Ee6l1tMMQqtO_Q" name="Package"/>
+  <packagedElement xsi:type="uml:Package" xmi:id="_SgrzwO03Ee6l1tMMQqtO_Q" name="Package"/>
+</uml:Model>

--- a/client/workspace/diagrams/package/package.unotation
+++ b/client/workspace/diagrams/package/package.unotation
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="ASCII"?>
+<unotation:UMLDiagram xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:notation="http://www.eclipse.org/glsp/notation" xmlns:unotation="http://www.borkdominik.com/big-glsp/uml/unotation" xmi:id="_E0HWEe03Ee6l1tMMQqtO_Q" diagramType="PACKAGE">
+  <semanticElement xmi:id="_E0iz4O03Ee6l1tMMQqtO_Q" elementId="_E0bfIO03Ee6l1tMMQqtO_Q"/>
+  <elements xsi:type="notation:Shape" xmi:id="_FSde8O03Ee6l1tMMQqtO_Q">
+    <semanticElement xmi:id="_FSde8e03Ee6l1tMMQqtO_Q" elementId="_FSaboO03Ee6l1tMMQqtO_Q"/>
+    <position xmi:id="_GC2aEO03Ee6l1tMMQqtO_Q" x="796.0" y="273.0"/>
+    <size xmi:id="_GC2aEe03Ee6l1tMMQqtO_Q" width="85.37239456176758" height="45.0"/>
+  </elements>
+  <elements xsi:type="notation:Shape" xmi:id="_FkqpQO03Ee6l1tMMQqtO_Q">
+    <semanticElement xmi:id="_FkqpQe03Ee6l1tMMQqtO_Q" elementId="_FkpbIO03Ee6l1tMMQqtO_Q"/>
+    <position xmi:id="_1ho1EO03Ee6Z2ZKhrJBG8w" x="426.0" y="259.0"/>
+    <size xmi:id="_1ho1Ee03Ee6Z2ZKhrJBG8w" width="113.171875" height="45.0"/>
+  </elements>
+  <elements xsi:type="notation:Edge" xmi:id="_GLbuUO03Ee6l1tMMQqtO_Q">
+    <semanticElement xmi:id="_GLbuUe03Ee6l1tMMQqtO_Q" elementId="_GLbHQO03Ee6l1tMMQqtO_Q"/>
+  </elements>
+  <elements xsi:type="notation:Shape" xmi:id="_LmwHgO03Ee6l1tMMQqtO_Q">
+    <semanticElement xmi:id="_LmwHge03Ee6l1tMMQqtO_Q" elementId="_LmvgcO03Ee6l1tMMQqtO_Q"/>
+    <position xmi:id="_MP5LIO03Ee6l1tMMQqtO_Q" x="627.0" y="430.0"/>
+    <size xmi:id="_MP5LIe03Ee6l1tMMQqtO_Q" width="85.37239456176758" height="45.0"/>
+  </elements>
+  <elements xsi:type="notation:Shape" xmi:id="_Mq0MkO03Ee6l1tMMQqtO_Q">
+    <semanticElement xmi:id="_Mq0Mke03Ee6l1tMMQqtO_Q" elementId="_MqzlgO03Ee6l1tMMQqtO_Q"/>
+    <position xmi:id="_Mq0Mku03Ee6l1tMMQqtO_Q" x="442.0" y="483.0"/>
+    <size xmi:id="_Mq0Mk-03Ee6l1tMMQqtO_Q" width="60.0" height="45.0"/>
+  </elements>
+  <elements xsi:type="notation:Edge" xmi:id="_NYKawe03Ee6l1tMMQqtO_Q">
+    <semanticElement xmi:id="_NYKawu03Ee6l1tMMQqtO_Q" elementId="_NYKawO03Ee6l1tMMQqtO_Q"/>
+  </elements>
+  <elements xsi:type="notation:Shape" xmi:id="_SgtB4O03Ee6l1tMMQqtO_Q">
+    <semanticElement xmi:id="_SgtB4e03Ee6l1tMMQqtO_Q" elementId="_SgrzwO03Ee6l1tMMQqtO_Q"/>
+    <position xmi:id="_T5G_QO03Ee6l1tMMQqtO_Q" x="631.0" y="106.0"/>
+    <size xmi:id="_T5G_Qe03Ee6l1tMMQqtO_Q" width="113.171875" height="45.0"/>
+  </elements>
+  <elements xsi:type="notation:Edge" xmi:id="_S7HtAO03Ee6l1tMMQqtO_Q">
+    <semanticElement xmi:id="_S7HtAe03Ee6l1tMMQqtO_Q" elementId="_S7HF8O03Ee6l1tMMQqtO_Q"/>
+  </elements>
+</unotation:UMLDiagram>

--- a/server/com.borkdominik.big.glsp.uml/src/main/java/com/borkdominik/big/glsp/uml/uml/UMLModule.java
+++ b/server/com.borkdominik.big.glsp.uml/src/main/java/com/borkdominik/big/glsp/uml/uml/UMLModule.java
@@ -12,6 +12,7 @@ package com.borkdominik.big.glsp.uml.uml;
 
 import com.borkdominik.big.glsp.uml.uml.elements.type.TypeInformationProvider;
 import com.borkdominik.big.glsp.uml.uml.representation.class_.UMLClassManifest;
+import com.borkdominik.big.glsp.uml.uml.representation.information_flow.UMLInformationFlowManifest;
 import com.borkdominik.big.glsp.uml.uml.representation.use_case.UMLUseCaseManifest;
 import com.google.inject.AbstractModule;
 import com.google.inject.Singleton;
@@ -25,6 +26,7 @@ public class UMLModule extends AbstractModule {
       bind(TypeInformationProvider.class).in(Singleton.class);
 
       install(new UMLClassManifest());
+      install(new UMLInformationFlowManifest());
       install(new UMLUseCaseManifest());
    }
 }

--- a/server/com.borkdominik.big.glsp.uml/src/main/java/com/borkdominik/big/glsp/uml/uml/UMLModule.java
+++ b/server/com.borkdominik.big.glsp.uml/src/main/java/com/borkdominik/big/glsp/uml/uml/UMLModule.java
@@ -12,6 +12,7 @@ package com.borkdominik.big.glsp.uml.uml;
 
 import com.borkdominik.big.glsp.uml.uml.elements.type.TypeInformationProvider;
 import com.borkdominik.big.glsp.uml.uml.representation.class_.UMLClassManifest;
+import com.borkdominik.big.glsp.uml.uml.representation.use_case.UMLUseCaseManifest;
 import com.google.inject.AbstractModule;
 import com.google.inject.Singleton;
 
@@ -24,5 +25,6 @@ public class UMLModule extends AbstractModule {
       bind(TypeInformationProvider.class).in(Singleton.class);
 
       install(new UMLClassManifest());
+      install(new UMLUseCaseManifest());
    }
 }

--- a/server/com.borkdominik.big.glsp.uml/src/main/java/com/borkdominik/big/glsp/uml/uml/UMLModule.java
+++ b/server/com.borkdominik.big.glsp.uml/src/main/java/com/borkdominik/big/glsp/uml/uml/UMLModule.java
@@ -13,6 +13,7 @@ package com.borkdominik.big.glsp.uml.uml;
 import com.borkdominik.big.glsp.uml.uml.elements.type.TypeInformationProvider;
 import com.borkdominik.big.glsp.uml.uml.representation.class_.UMLClassManifest;
 import com.borkdominik.big.glsp.uml.uml.representation.information_flow.UMLInformationFlowManifest;
+import com.borkdominik.big.glsp.uml.uml.representation.package_.UMLPackageManifest;
 import com.borkdominik.big.glsp.uml.uml.representation.use_case.UMLUseCaseManifest;
 import com.google.inject.AbstractModule;
 import com.google.inject.Singleton;
@@ -27,6 +28,7 @@ public class UMLModule extends AbstractModule {
 
       install(new UMLClassManifest());
       install(new UMLInformationFlowManifest());
+      install(new UMLPackageManifest());
       install(new UMLUseCaseManifest());
    }
 }

--- a/server/com.borkdominik.big.glsp.uml/src/main/java/com/borkdominik/big/glsp/uml/uml/UMLTypes.java
+++ b/server/com.borkdominik.big.glsp.uml/src/main/java/com/borkdominik/big/glsp/uml/uml/UMLTypes.java
@@ -81,6 +81,7 @@ public enum UMLTypes implements BGTypeProvider {
    ASSOCIATION(List.of(Association.class)),
    CLASS(List.of(org.eclipse.uml2.uml.Class.class)),
    COMMUNICATION_PATH(List.of(CommunicationPath.class)),
+   COMPONENT(List.of(Component.class)),
    COMPOSITION("Composition"),
    CONTROL_FLOW(List.of(ControlFlow.class)),
    DATA_TYPE(List.of(DataType.class)),
@@ -123,11 +124,10 @@ public enum UMLTypes implements BGTypeProvider {
    SLOT(List.of(Slot.class)),
    STATE(List.of(State.class)),
    STATE_MACHINE(List.of(StateMachine.class)),
-   SUBJECT(List.of(Component.class)),
    SUBSTITUTION(List.of(Substitution.class)),
    TRANSITION(List.of(Transition.class)),
    USAGE(List.of(Usage.class)),
-   USECASE(List.of(UseCase.class));
+   USE_CASE(List.of(UseCase.class));
 
    private final String typeId;
    private final Collection<Class<? extends EObject>> handledElements;

--- a/server/com.borkdominik.big.glsp.uml/src/main/java/com/borkdominik/big/glsp/uml/uml/elements/actor/ActorConfiguration.java
+++ b/server/com.borkdominik.big.glsp.uml/src/main/java/com/borkdominik/big/glsp/uml/uml/elements/actor/ActorConfiguration.java
@@ -1,0 +1,54 @@
+/********************************************************************************
+ * Copyright (c) 2023 borkdominik and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0, or the MIT License which is
+ * available at https://opensource.org/licenses/MIT.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR MIT
+ ********************************************************************************/
+package com.borkdominik.big.glsp.uml.uml.elements.actor;
+
+import java.util.Map;
+import java.util.Set;
+
+import org.eclipse.emf.common.util.Enumerator;
+import org.eclipse.emf.ecore.EClass;
+import org.eclipse.glsp.graph.GraphPackage;
+import org.eclipse.glsp.server.types.ShapeTypeHint;
+
+import com.borkdominik.big.glsp.server.core.model.BGTypeProvider;
+import com.borkdominik.big.glsp.server.elements.configuration.base.BGBaseNodeConfiguration;
+import com.borkdominik.big.glsp.uml.uml.UMLTypes;
+import com.google.inject.Inject;
+import com.google.inject.assistedinject.Assisted;
+
+public class ActorConfiguration extends BGBaseNodeConfiguration {
+   protected final String typeId = UMLTypes.ACTOR.prefix(representation);
+   protected final String stickfigureId = UMLTypes.ACTOR_STICKFIGURE.prefix(representation);
+
+   @Inject
+   public ActorConfiguration(@Assisted final Enumerator representation,
+      @Assisted final Set<BGTypeProvider> elementTypes) {
+      super(representation, elementTypes);
+   }
+
+   @Override
+   public Map<String, EClass> getTypeMappings() {
+      return Map.of(
+         typeId, GraphPackage.Literals.GNODE,
+         stickfigureId, GraphPackage.Literals.GNODE);
+   }
+
+   @Override
+   public Set<String> getGraphContainableElements() { return Set.of(typeId); }
+
+   @Override
+   public Set<ShapeTypeHint> getShapeTypeHints() {
+      return Set.of(
+         new ShapeTypeHint(typeId, true, true, true, false,
+            elementConfig().existingConfigurationTypeIds(Set.of())));
+   }
+
+}

--- a/server/com.borkdominik.big.glsp.uml/src/main/java/com/borkdominik/big/glsp/uml/uml/elements/actor/ActorElementManifest.java
+++ b/server/com.borkdominik.big.glsp.uml/src/main/java/com/borkdominik/big/glsp/uml/uml/elements/actor/ActorElementManifest.java
@@ -1,0 +1,38 @@
+/********************************************************************************
+ * Copyright (c) 2023 borkdominik and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0, or the MIT License which is
+ * available at https://opensource.org/licenses/MIT.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR MIT
+ ********************************************************************************/
+package com.borkdominik.big.glsp.uml.uml.elements.actor;
+
+import java.util.Set;
+
+import com.borkdominik.big.glsp.server.core.manifest.BGRepresentationManifest;
+import com.borkdominik.big.glsp.server.elements.manifest.integrations.BGEMFNodeElementManifest;
+import com.borkdominik.big.glsp.server.features.property_palette.BGPropertyPaletteContribution;
+import com.borkdominik.big.glsp.uml.uml.UMLTypes;
+import com.borkdominik.big.glsp.uml.uml.elements.actor.gmodel.ActorGModelMapper;
+import com.borkdominik.big.glsp.uml.uml.elements.named_element.NamedElementLabelEditHandler;
+import com.borkdominik.big.glsp.uml.uml.elements.named_element.NamedElementPropertyProvider;
+
+public class ActorElementManifest extends BGEMFNodeElementManifest {
+   public ActorElementManifest(final BGRepresentationManifest manifest) {
+      super(manifest, Set.of(UMLTypes.ACTOR));
+   }
+
+   @Override
+   protected void configureElement() {
+      bindGModelMapper(ActorGModelMapper.class);
+      bindConfiguration(ActorConfiguration.class);
+      bindCreateHandler(ActorOperationHandler.class);
+      bindEditLabel(Set.of(NamedElementLabelEditHandler.class));
+      bindPropertyPalette(BGPropertyPaletteContribution.Options.builder()
+         .propertyProviders(Set.of(
+            NamedElementPropertyProvider.class)));
+   }
+}

--- a/server/com.borkdominik.big.glsp.uml/src/main/java/com/borkdominik/big/glsp/uml/uml/elements/actor/ActorOperationHandler.java
+++ b/server/com.borkdominik.big.glsp.uml/src/main/java/com/borkdominik/big/glsp/uml/uml/elements/actor/ActorOperationHandler.java
@@ -1,0 +1,49 @@
+/********************************************************************************
+ * Copyright (c) 2023 borkdominik and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0, or the MIT License which is
+ * available at https://opensource.org/licenses/MIT.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR MIT
+ ********************************************************************************/
+package com.borkdominik.big.glsp.uml.uml.elements.actor;
+
+import java.util.Set;
+
+import org.eclipse.emf.common.util.Enumerator;
+import org.eclipse.glsp.server.operations.CreateNodeOperation;
+import org.eclipse.uml2.uml.Actor;
+import org.eclipse.uml2.uml.Package;
+import org.eclipse.uml2.uml.UMLFactory;
+
+import com.borkdominik.big.glsp.server.core.commands.semantic.BGCreateNodeSemanticCommand;
+import com.borkdominik.big.glsp.server.core.model.BGTypeProvider;
+import com.borkdominik.big.glsp.server.elements.handler.operations.integrations.BGEMFNodeOperationHandler;
+import com.borkdominik.big.glsp.uml.uml.elements.packageable_element.CreatePackagableElementCommand;
+import com.google.inject.Inject;
+import com.google.inject.assistedinject.Assisted;
+
+public class ActorOperationHandler extends BGEMFNodeOperationHandler<Actor, Package> {
+
+   @Inject
+   public ActorOperationHandler(@Assisted final Enumerator representation,
+      @Assisted final Set<BGTypeProvider> elementTypes) {
+      super(representation, elementTypes);
+
+   }
+
+   @Override
+   protected BGCreateNodeSemanticCommand<Actor, Package, ?> createSemanticCommand(
+      final CreateNodeOperation operation,
+      final Package parent) {
+      var argument = CreatePackagableElementCommand.Argument
+         .<Actor> createPackageableElementArgumentBuilder()
+         .supplier((p) -> UMLFactory.eINSTANCE.createActor())
+         .build();
+
+      return new CreatePackagableElementCommand<>(commandContext, parent, argument);
+   }
+
+}

--- a/server/com.borkdominik.big.glsp.uml/src/main/java/com/borkdominik/big/glsp/uml/uml/elements/actor/gmodel/ActorGModelMapper.java
+++ b/server/com.borkdominik.big.glsp.uml/src/main/java/com/borkdominik/big/glsp/uml/uml/elements/actor/gmodel/ActorGModelMapper.java
@@ -1,0 +1,51 @@
+/********************************************************************************
+ * Copyright (c) 2021-2022 borkdominik and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0, or the MIT License which is
+ * available at https://opensource.org/licenses/MIT.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR MIT
+ ********************************************************************************/
+package com.borkdominik.big.glsp.uml.uml.elements.actor.gmodel;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+
+import org.eclipse.emf.common.util.Enumerator;
+import org.eclipse.glsp.graph.GModelElement;
+import org.eclipse.glsp.graph.GNode;
+import org.eclipse.uml2.uml.Actor;
+
+import com.borkdominik.big.glsp.server.core.model.BGTypeProvider;
+import com.borkdominik.big.glsp.server.elements.gmodel.BGEMFElementGModelMapper;
+import com.borkdominik.big.glsp.uml.uml.UMLTypes;
+import com.google.inject.Inject;
+import com.google.inject.assistedinject.Assisted;
+
+public final class ActorGModelMapper extends BGEMFElementGModelMapper<Actor, GNode> {
+
+   @Inject
+   public ActorGModelMapper(@Assisted final Enumerator representation,
+      @Assisted final Set<BGTypeProvider> elementTypes) {
+      super(representation, elementTypes);
+   }
+
+   @Override
+   public GNode map(final Actor source) {
+      return new GActorBuilder<>(gcmodelContext, source, UMLTypes.ACTOR.prefix(representation))
+         .buildGModel();
+   }
+
+   @Override
+   public List<GModelElement> mapSiblings(final Actor source) {
+      var siblings = new ArrayList<GModelElement>();
+
+      siblings.addAll(mapHandler.handle(source.getGeneralizations()));
+
+      return siblings;
+   }
+
+}

--- a/server/com.borkdominik.big.glsp.uml/src/main/java/com/borkdominik/big/glsp/uml/uml/elements/actor/gmodel/GActorBuilder.java
+++ b/server/com.borkdominik.big.glsp.uml/src/main/java/com/borkdominik/big/glsp/uml/uml/elements/actor/gmodel/GActorBuilder.java
@@ -1,0 +1,66 @@
+/********************************************************************************
+ * Copyright (c) 2023 borkdominik and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0, or the MIT License which is
+ * available at https://opensource.org/licenses/MIT.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR MIT
+ ********************************************************************************/
+package com.borkdominik.big.glsp.uml.uml.elements.actor.gmodel;
+
+import java.util.List;
+
+import org.eclipse.glsp.graph.GNode;
+import org.eclipse.glsp.graph.builder.impl.GNodeBuilder;
+import org.eclipse.glsp.graph.util.GConstants;
+import org.eclipse.uml2.uml.Actor;
+
+import com.borkdominik.big.glsp.server.core.constants.BGCoreCSS;
+import com.borkdominik.big.glsp.server.sdk.cdk.GCModelContext;
+import com.borkdominik.big.glsp.server.sdk.cdk.base.GCProvider;
+import com.borkdominik.big.glsp.server.sdk.cdk.gmodel.GCModelElement;
+import com.borkdominik.big.glsp.server.sdk.cdk.gmodel.GCModelList;
+import com.borkdominik.big.glsp.server.sdk.gmodel.BCCompartmentBuilder;
+import com.borkdominik.big.glsp.server.sdk.gmodel.BCLayoutOptions;
+import com.borkdominik.big.glsp.server.sdk.ui.builder.GCNodeBuilder;
+import com.borkdominik.big.glsp.uml.uml.UMLTypes;
+import com.borkdominik.big.glsp.uml.uml.elements.named_element.GCNamedElement;
+
+public final class GActorBuilder<TOrigin extends Actor> extends GCNodeBuilder<TOrigin> {
+
+   public GActorBuilder(final GCModelContext context, final TOrigin origin, final String type) {
+      super(context, origin, type);
+   }
+
+   @Override
+   protected GCModelList<?, ?> createRootComponent(final GNode gmodelRoot) {
+      var componentRoot = new GCModelList<>(context, origin,
+         new BCCompartmentBuilder<>(origin, context)
+            .withRootComponentLayout()
+            .addLayoutOptions(new BCLayoutOptions().hAlign(GConstants.HAlign.CENTER).vGap(5))
+            .build());
+
+      componentRoot.addAll(createComponentChildren(gmodelRoot, componentRoot));
+
+      return componentRoot;
+   }
+
+   @Override
+   protected List<GCProvider> createComponentChildren(final GNode gmodelRoot, final GCModelList<?, ?> root) {
+      var figure = new GCModelElement<>(context, origin, new GNodeBuilder(
+         UMLTypes.ACTOR_STICKFIGURE.prefix(context.representation()))
+            .id(context.idCountGenerator.getOrCreateId(origin))
+            .addCssClass(BGCoreCSS.NODE)
+            .build());
+
+      var namedElementOptions = GCNamedElement.Options.builder()
+         .container(root)
+         .build();
+
+      var name = new GCNamedElement<>(context, origin, namedElementOptions);
+
+      return List.of(figure, name);
+   }
+}

--- a/server/com.borkdominik.big.glsp.uml/src/main/java/com/borkdominik/big/glsp/uml/uml/elements/association/AssociationConfiguration.java
+++ b/server/com.borkdominik.big.glsp.uml/src/main/java/com/borkdominik/big/glsp/uml/uml/elements/association/AssociationConfiguration.java
@@ -51,7 +51,7 @@ public class AssociationConfiguration extends BGBaseEdgeConfiguration {
                .existingConfigurationTypeIds(Set.of(UMLTypes.CLASS, UMLTypes.INTERFACE, UMLTypes.ACTOR)),
             elementConfig()
                .existingConfigurationTypeIds(
-                  Set.of(UMLTypes.CLASS, UMLTypes.INTERFACE, UMLTypes.USECASE))),
+                  Set.of(UMLTypes.CLASS, UMLTypes.INTERFACE, UMLTypes.USE_CASE))),
 
          new EdgeTypeHint(aggregationTypeId, true, true, true,
             elementConfig().existingConfigurationTypeIds(Set.of(UMLTypes.CLASS, UMLTypes.INTERFACE)),

--- a/server/com.borkdominik.big.glsp.uml/src/main/java/com/borkdominik/big/glsp/uml/uml/elements/association/AssociationOperationHandler.java
+++ b/server/com.borkdominik.big.glsp.uml/src/main/java/com/borkdominik/big/glsp/uml/uml/elements/association/AssociationOperationHandler.java
@@ -17,6 +17,7 @@ import org.eclipse.emf.common.command.Command;
 import org.eclipse.emf.common.command.CompoundCommand;
 import org.eclipse.emf.common.util.Enumerator;
 import org.eclipse.emf.ecore.EObject;
+import org.eclipse.emf.ecore.util.EcoreUtil;
 import org.eclipse.glsp.server.operations.CreateEdgeOperation;
 import org.eclipse.glsp.server.operations.DeleteOperation;
 import org.eclipse.glsp.server.operations.ReconnectEdgeOperation;
@@ -81,13 +82,15 @@ public class AssociationOperationHandler extends BGEMFEdgeOperationHandler<Assoc
       var semanticElement = modelState.getElementIndex().getSemanticOrThrow(object, Association.class);
 
       var command = new CompoundCommand();
+      for (var end : semanticElement.getMemberEnds()) {
+         if (!EcoreUtil.isAncestor(semanticElement, end)) {
+            command.append(new BGDeleteElementSemanticCommand(commandContext, modelState.getSemanticModel(), end));
+         }
+      }
+
       command
          .append(new BGDeleteElementSemanticCommand(commandContext, modelState.getSemanticModel(), semanticElement));
       command.append(new BGEMFDeleteNotationCommand(commandContext, semanticElement));
-
-      for (var end : semanticElement.getMemberEnds()) {
-         command.append(new BGDeleteElementSemanticCommand(commandContext, modelState.getSemanticModel(), end));
-      }
 
       return Optional.of(command);
    }

--- a/server/com.borkdominik.big.glsp.uml/src/main/java/com/borkdominik/big/glsp/uml/uml/elements/association/features/AssociationPropertyProvider.java
+++ b/server/com.borkdominik.big.glsp.uml/src/main/java/com/borkdominik/big/glsp/uml/uml/elements/association/features/AssociationPropertyProvider.java
@@ -21,6 +21,7 @@ import com.borkdominik.big.glsp.server.core.model.BGTypeProvider;
 import com.borkdominik.big.glsp.server.features.property_palette.model.ElementPropertyBuilder;
 import com.borkdominik.big.glsp.server.features.property_palette.model.ElementPropertyItem;
 import com.borkdominik.big.glsp.server.features.property_palette.provider.integrations.BGEMFElementPropertyProvider;
+import com.borkdominik.big.glsp.uml.uml.UMLTypes;
 import com.borkdominik.big.glsp.uml.uml.elements.element.VisibilityKindUtils;
 import com.borkdominik.big.glsp.uml.uml.elements.multiplicity_element.MultiplicityElementPropertyProvider;
 import com.borkdominik.big.glsp.uml.uml.elements.multiplicity_element.MultiplicityUtil;
@@ -39,34 +40,39 @@ public class AssociationPropertyProvider extends BGEMFElementPropertyProvider<As
    @Override
    public List<ElementPropertyItem> doProvide(final Association element) {
       var memberEnds = element.getMemberEnds();
-      var sourceProperty = memberEnds.get(0);
-      var sourcePropertyId = idGenerator.getOrCreateId(sourceProperty);
-      var targetProperty = memberEnds.get(1);
-      var targetPropertyId = idGenerator.getOrCreateId(targetProperty);
-
-      var sourceProperties = new ElementPropertyBuilder(sourcePropertyId)
-         .text(NamedElementPropertyProvider.NAME, "Source Name", sourceProperty.getName())
-         .choice(
-            NamedElementPropertyProvider.VISIBILITY_KIND,
-            "Source Visibility",
-            VisibilityKindUtils.asChoices(),
-            sourceProperty.getVisibility().getLiteral())
-         .text(MultiplicityElementPropertyProvider.MULTIPLICITY, "Source Multiplicity",
-            MultiplicityUtil.getMultiplicity(sourceProperty));
-
-      var targetProperties = new ElementPropertyBuilder(targetPropertyId)
-         .text(NamedElementPropertyProvider.NAME, "Target Name", targetProperty.getName())
-         .choice(
-            NamedElementPropertyProvider.VISIBILITY_KIND,
-            "Target Visibility",
-            VisibilityKindUtils.asChoices(),
-            targetProperty.getVisibility().getLiteral())
-         .text(MultiplicityElementPropertyProvider.MULTIPLICITY, "Target Multiplicity",
-            MultiplicityUtil.getMultiplicity(targetProperty));
 
       var properties = new ArrayList<ElementPropertyItem>();
-      properties.addAll(sourceProperties.items());
-      properties.addAll(targetProperties.items());
+      properties.addAll(provideIfConfigured(Set.of(UMLTypes.PROPERTY), () -> {
+         var sourceProperty = memberEnds.get(0);
+         var sourcePropertyId = idGenerator.getOrCreateId(sourceProperty);
+
+         return new ElementPropertyBuilder(sourcePropertyId)
+            .text(NamedElementPropertyProvider.NAME, "Source Name", sourceProperty.getName())
+            .choice(
+               NamedElementPropertyProvider.VISIBILITY_KIND,
+               "Source Visibility",
+               VisibilityKindUtils.asChoices(),
+               sourceProperty.getVisibility().getLiteral())
+            .text(MultiplicityElementPropertyProvider.MULTIPLICITY, "Source Multiplicity",
+               MultiplicityUtil.getMultiplicity(sourceProperty))
+            .items();
+
+      }));
+      properties.addAll(provideIfConfigured(Set.of(UMLTypes.PROPERTY), () -> {
+         var targetProperty = memberEnds.get(1);
+         var targetPropertyId = idGenerator.getOrCreateId(targetProperty);
+
+         return new ElementPropertyBuilder(targetPropertyId)
+            .text(NamedElementPropertyProvider.NAME, "Target Name", targetProperty.getName())
+            .choice(
+               NamedElementPropertyProvider.VISIBILITY_KIND,
+               "Target Visibility",
+               VisibilityKindUtils.asChoices(),
+               targetProperty.getVisibility().getLiteral())
+            .text(MultiplicityElementPropertyProvider.MULTIPLICITY, "Target Multiplicity",
+               MultiplicityUtil.getMultiplicity(targetProperty))
+            .items();
+      }));
       return properties;
    }
 }

--- a/server/com.borkdominik.big.glsp.uml/src/main/java/com/borkdominik/big/glsp/uml/uml/elements/component/ComponentConfiguration.java
+++ b/server/com.borkdominik.big.glsp.uml/src/main/java/com/borkdominik/big/glsp/uml/uml/elements/component/ComponentConfiguration.java
@@ -1,0 +1,50 @@
+/********************************************************************************
+ * Copyright (c) 2023 borkdominik and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0, or the MIT License which is
+ * available at https://opensource.org/licenses/MIT.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR MIT
+ ********************************************************************************/
+package com.borkdominik.big.glsp.uml.uml.elements.component;
+
+import java.util.Map;
+import java.util.Set;
+
+import org.eclipse.emf.common.util.Enumerator;
+import org.eclipse.emf.ecore.EClass;
+import org.eclipse.glsp.graph.GraphPackage;
+import org.eclipse.glsp.server.types.ShapeTypeHint;
+
+import com.borkdominik.big.glsp.server.core.model.BGTypeProvider;
+import com.borkdominik.big.glsp.server.elements.configuration.base.BGBaseNodeConfiguration;
+import com.borkdominik.big.glsp.uml.uml.UMLTypes;
+import com.google.inject.Inject;
+import com.google.inject.assistedinject.Assisted;
+
+public class ComponentConfiguration extends BGBaseNodeConfiguration {
+   protected final String typeId = UMLTypes.COMPONENT.prefix(representation);
+
+   @Inject
+   public ComponentConfiguration(@Assisted final Enumerator representation,
+      @Assisted final Set<BGTypeProvider> elementTypes) {
+      super(representation, elementTypes);
+   }
+
+   @Override
+   public Map<String, EClass> getTypeMappings() { return Map.of(
+      typeId, GraphPackage.Literals.GNODE); }
+
+   @Override
+   public Set<String> getGraphContainableElements() { return Set.of(typeId); }
+
+   @Override
+   public Set<ShapeTypeHint> getShapeTypeHints() {
+      return Set.of(
+         new ShapeTypeHint(typeId, true, true, true, false,
+            elementConfig().existingConfigurationTypeIds(Set.of(UMLTypes.USE_CASE))));
+   }
+
+}

--- a/server/com.borkdominik.big.glsp.uml/src/main/java/com/borkdominik/big/glsp/uml/uml/elements/component/ComponentElementManifest.java
+++ b/server/com.borkdominik.big.glsp.uml/src/main/java/com/borkdominik/big/glsp/uml/uml/elements/component/ComponentElementManifest.java
@@ -1,0 +1,38 @@
+/********************************************************************************
+ * Copyright (c) 2023 borkdominik and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0, or the MIT License which is
+ * available at https://opensource.org/licenses/MIT.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR MIT
+ ********************************************************************************/
+package com.borkdominik.big.glsp.uml.uml.elements.component;
+
+import java.util.Set;
+
+import com.borkdominik.big.glsp.server.core.manifest.BGRepresentationManifest;
+import com.borkdominik.big.glsp.server.elements.manifest.integrations.BGEMFNodeElementManifest;
+import com.borkdominik.big.glsp.server.features.property_palette.BGPropertyPaletteContribution;
+import com.borkdominik.big.glsp.uml.uml.UMLTypes;
+import com.borkdominik.big.glsp.uml.uml.elements.component.gmodel.ComponentGModelMapper;
+import com.borkdominik.big.glsp.uml.uml.elements.named_element.NamedElementLabelEditHandler;
+import com.borkdominik.big.glsp.uml.uml.elements.named_element.NamedElementPropertyProvider;
+
+public class ComponentElementManifest extends BGEMFNodeElementManifest {
+   public ComponentElementManifest(final BGRepresentationManifest manifest) {
+      super(manifest, Set.of(UMLTypes.COMPONENT));
+   }
+
+   @Override
+   protected void configureElement() {
+      bindGModelMapper(ComponentGModelMapper.class);
+      bindConfiguration(ComponentConfiguration.class);
+      bindCreateHandler(ComponentOperationHandler.class);
+      bindEditLabel(Set.of(NamedElementLabelEditHandler.class));
+      bindPropertyPalette(BGPropertyPaletteContribution.Options.builder()
+         .propertyProviders(Set.of(
+            NamedElementPropertyProvider.class)));
+   }
+}

--- a/server/com.borkdominik.big.glsp.uml/src/main/java/com/borkdominik/big/glsp/uml/uml/elements/component/ComponentOperationHandler.java
+++ b/server/com.borkdominik.big.glsp.uml/src/main/java/com/borkdominik/big/glsp/uml/uml/elements/component/ComponentOperationHandler.java
@@ -1,0 +1,51 @@
+/********************************************************************************
+ * Copyright (c) 2023 borkdominik and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0, or the MIT License which is
+ * available at https://opensource.org/licenses/MIT.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR MIT
+ ********************************************************************************/
+package com.borkdominik.big.glsp.uml.uml.elements.component;
+
+import java.util.Set;
+
+import org.eclipse.emf.common.util.Enumerator;
+import org.eclipse.glsp.server.operations.CreateNodeOperation;
+import org.eclipse.uml2.uml.Component;
+import org.eclipse.uml2.uml.Package;
+import org.eclipse.uml2.uml.UMLFactory;
+
+import com.borkdominik.big.glsp.server.core.commands.semantic.BGCreateNodeSemanticCommand;
+import com.borkdominik.big.glsp.server.core.model.BGTypeProvider;
+import com.borkdominik.big.glsp.server.elements.handler.operations.integrations.BGEMFNodeOperationHandler;
+import com.borkdominik.big.glsp.uml.uml.elements.packageable_element.CreatePackagableElementCommand;
+import com.google.inject.Inject;
+import com.google.inject.assistedinject.Assisted;
+
+public class ComponentOperationHandler extends BGEMFNodeOperationHandler<Component, Package> {
+
+   @Inject
+   public ComponentOperationHandler(@Assisted final Enumerator representation,
+      @Assisted final Set<BGTypeProvider> elementTypes) {
+      super(representation, elementTypes);
+
+   }
+
+   @Override
+   protected BGCreateNodeSemanticCommand<Component, Package, ?> createSemanticCommand(
+      final CreateNodeOperation operation,
+      final Package parent) {
+      var argument = CreatePackagableElementCommand.Argument
+         .<Component> createPackageableElementArgumentBuilder()
+         .supplier((p) -> UMLFactory.eINSTANCE.createComponent())
+         .build();
+
+      return new CreatePackagableElementCommand<>(
+         commandContext, parent, argument);
+
+   }
+
+}

--- a/server/com.borkdominik.big.glsp.uml/src/main/java/com/borkdominik/big/glsp/uml/uml/elements/component/gmodel/ComponentGModelMapper.java
+++ b/server/com.borkdominik.big.glsp.uml/src/main/java/com/borkdominik/big/glsp/uml/uml/elements/component/gmodel/ComponentGModelMapper.java
@@ -1,0 +1,39 @@
+/********************************************************************************
+ * Copyright (c) 2021-2022 borkdominik and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0, or the MIT License which is
+ * available at https://opensource.org/licenses/MIT.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR MIT
+ ********************************************************************************/
+package com.borkdominik.big.glsp.uml.uml.elements.component.gmodel;
+
+import java.util.Set;
+
+import org.eclipse.emf.common.util.Enumerator;
+import org.eclipse.glsp.graph.GNode;
+import org.eclipse.uml2.uml.Component;
+
+import com.borkdominik.big.glsp.server.core.model.BGTypeProvider;
+import com.borkdominik.big.glsp.server.elements.gmodel.BGEMFElementGModelMapper;
+import com.borkdominik.big.glsp.uml.uml.UMLTypes;
+import com.google.inject.Inject;
+import com.google.inject.assistedinject.Assisted;
+
+public final class ComponentGModelMapper extends BGEMFElementGModelMapper<Component, GNode> {
+
+   @Inject
+   public ComponentGModelMapper(@Assisted final Enumerator representation,
+      @Assisted final Set<BGTypeProvider> elementTypes) {
+      super(representation, elementTypes);
+   }
+
+   @Override
+   public GNode map(final Component source) {
+      return new GComponentBuilder<>(gcmodelContext, source, UMLTypes.COMPONENT.prefix(representation))
+         .buildGModel();
+   }
+
+}

--- a/server/com.borkdominik.big.glsp.uml/src/main/java/com/borkdominik/big/glsp/uml/uml/elements/component/gmodel/GComponentBuilder.java
+++ b/server/com.borkdominik.big.glsp.uml/src/main/java/com/borkdominik/big/glsp/uml/uml/elements/component/gmodel/GComponentBuilder.java
@@ -1,0 +1,78 @@
+/********************************************************************************
+ * Copyright (c) 2023 borkdominik and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0, or the MIT License which is
+ * available at https://opensource.org/licenses/MIT.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR MIT
+ ********************************************************************************/
+package com.borkdominik.big.glsp.uml.uml.elements.component.gmodel;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.eclipse.glsp.graph.GNode;
+import org.eclipse.glsp.graph.util.GConstants;
+import org.eclipse.uml2.uml.Component;
+
+import com.borkdominik.big.glsp.server.core.constants.BGQuotationMark;
+import com.borkdominik.big.glsp.server.sdk.cdk.GCModelContext;
+import com.borkdominik.big.glsp.server.sdk.cdk.base.GCProvider;
+import com.borkdominik.big.glsp.server.sdk.cdk.gmodel.GCModelList;
+import com.borkdominik.big.glsp.server.sdk.gmodel.BCCompartmentBuilder;
+import com.borkdominik.big.glsp.server.sdk.gmodel.BCLayoutOptions;
+import com.borkdominik.big.glsp.server.sdk.ui.builder.GCNodeBuilder;
+import com.borkdominik.big.glsp.uml.uml.elements.named_element.GCNamedElement;
+
+public final class GComponentBuilder<TOrigin extends Component> extends GCNodeBuilder<TOrigin> {
+
+   public GComponentBuilder(final GCModelContext context, final TOrigin origin, final String type) {
+      super(context, origin, type);
+   }
+
+   @Override
+   protected GCModelList<?, ?> createRootComponent(final GNode gmodelRoot) {
+      var componentRoot = new GCModelList<>(context, origin,
+         new BCCompartmentBuilder<>(origin, context)
+            .withRootComponentLayout()
+            .addLayoutOptions(new BCLayoutOptions().hAlign(GConstants.HAlign.CENTER).vGap(5))
+            .build());
+
+      componentRoot.addAll(createComponentChildren(gmodelRoot, componentRoot));
+
+      return componentRoot;
+   }
+
+   @Override
+   protected List<GCProvider> createComponentChildren(final GNode gmodelRoot, final GCModelList<?, ?> root) {
+      return List.of(createHeader(root), createBody(root));
+   }
+
+   protected GCProvider createHeader(final GCModelList<?, ?> root) {
+      var namedElementOptions = GCNamedElement.Options.builder()
+         .container(root)
+         .prefix((BGQuotationMark.quoteDoubleAngle("Subsystem")))
+         .build();
+      return new GCNamedElement<>(context, origin, namedElementOptions);
+   }
+
+   protected GCProvider createBody(final GCModelList<?, ?> root) {
+      var list = new GCModelList<>(context, origin, new BCCompartmentBuilder<>(origin, context)
+         .withFreeformLayout()
+         .build());
+
+      list.addAllGModels(origin.getOwnedUseCases().stream()
+         .map(e -> context.mapHandler.handle(e))
+         .collect(Collectors.toList()));
+      list.addAllGModels(origin.getOwnedUseCases().stream()
+         .map(e -> context.mapHandler.handleSiblings(e))
+         .flatMap(Collection::stream)
+         .collect(Collectors.toList()));
+
+      return list;
+   }
+
+}

--- a/server/com.borkdominik.big.glsp.uml/src/main/java/com/borkdominik/big/glsp/uml/uml/elements/element_import/ElementImportConfiguration.java
+++ b/server/com.borkdominik.big.glsp.uml/src/main/java/com/borkdominik/big/glsp/uml/uml/elements/element_import/ElementImportConfiguration.java
@@ -1,0 +1,46 @@
+/********************************************************************************
+ * Copyright (c) 2023 borkdominik and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0, or the MIT License which is
+ * available at https://opensource.org/licenses/MIT.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR MIT
+ ********************************************************************************/
+package com.borkdominik.big.glsp.uml.uml.elements.element_import;
+
+import java.util.Map;
+import java.util.Set;
+
+import org.eclipse.emf.common.util.Enumerator;
+import org.eclipse.emf.ecore.EClass;
+import org.eclipse.glsp.graph.GraphPackage;
+import org.eclipse.glsp.server.types.EdgeTypeHint;
+
+import com.borkdominik.big.glsp.server.core.model.BGTypeProvider;
+import com.borkdominik.big.glsp.server.elements.configuration.base.BGBaseEdgeConfiguration;
+import com.borkdominik.big.glsp.uml.uml.UMLTypes;
+import com.google.inject.Inject;
+import com.google.inject.assistedinject.Assisted;
+
+public class ElementImportConfiguration extends BGBaseEdgeConfiguration {
+   protected final String typeId = UMLTypes.PACKAGE_IMPORT.prefix(representation);
+
+   @Inject
+   public ElementImportConfiguration(@Assisted final Enumerator representation,
+      @Assisted final Set<BGTypeProvider> elementTypes) {
+      super(representation, elementTypes);
+   }
+
+   @Override
+   public Map<String, EClass> getTypeMappings() { return Map.of(typeId, GraphPackage.Literals.GEDGE); }
+
+   @Override
+   public Set<EdgeTypeHint> getEdgeTypeHints() {
+      return Set.of(
+         new EdgeTypeHint(typeId, true, true, true,
+            elementConfig().existingConfigurationTypeIds(Set.of(UMLTypes.PACKAGE)),
+            elementConfig().existingConfigurationTypeIds(Set.of(UMLTypes.PACKAGE))));
+   }
+}

--- a/server/com.borkdominik.big.glsp.uml/src/main/java/com/borkdominik/big/glsp/uml/uml/elements/element_import/ElementImportElementManifest.java
+++ b/server/com.borkdominik.big.glsp.uml/src/main/java/com/borkdominik/big/glsp/uml/uml/elements/element_import/ElementImportElementManifest.java
@@ -1,0 +1,36 @@
+/********************************************************************************
+ * Copyright (c) 2023 borkdominik and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0, or the MIT License which is
+ * available at https://opensource.org/licenses/MIT.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR MIT
+ ********************************************************************************/
+package com.borkdominik.big.glsp.uml.uml.elements.element_import;
+
+import java.util.Set;
+
+import com.borkdominik.big.glsp.server.core.manifest.BGRepresentationManifest;
+import com.borkdominik.big.glsp.server.elements.manifest.integrations.BGEMFEdgeElementManifest;
+import com.borkdominik.big.glsp.server.features.property_palette.BGPropertyPaletteContribution;
+import com.borkdominik.big.glsp.uml.uml.UMLTypes;
+import com.borkdominik.big.glsp.uml.uml.elements.element_import.features.ElementImportPropertyProvider;
+import com.borkdominik.big.glsp.uml.uml.elements.element_import.gmodel.ElementImportGModelMapper;
+
+public class ElementImportElementManifest extends BGEMFEdgeElementManifest {
+   public ElementImportElementManifest(final BGRepresentationManifest manifest) {
+      super(manifest, Set.of(UMLTypes.ELEMENT_IMPORT));
+   }
+
+   @Override
+   protected void configureElement() {
+      bindGModelMapper(ElementImportGModelMapper.class);
+      bindConfiguration(ElementImportConfiguration.class);
+      bindCreateHandler(ElementImportOperationHandler.class);
+      bindPropertyPalette(BGPropertyPaletteContribution.Options.builder()
+         .propertyProviders(Set.of(
+            ElementImportPropertyProvider.class)));
+   }
+}

--- a/server/com.borkdominik.big.glsp.uml/src/main/java/com/borkdominik/big/glsp/uml/uml/elements/element_import/ElementImportOperationHandler.java
+++ b/server/com.borkdominik.big.glsp.uml/src/main/java/com/borkdominik/big/glsp/uml/uml/elements/element_import/ElementImportOperationHandler.java
@@ -1,0 +1,51 @@
+/********************************************************************************
+ * Copyright (c) 2023 borkdominik and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0, or the MIT License which is
+ * available at https://opensource.org/licenses/MIT.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR MIT
+ ********************************************************************************/
+package com.borkdominik.big.glsp.uml.uml.elements.element_import;
+
+import java.util.Set;
+
+import org.eclipse.emf.common.util.Enumerator;
+import org.eclipse.glsp.server.operations.CreateEdgeOperation;
+import org.eclipse.uml2.uml.ElementImport;
+import org.eclipse.uml2.uml.Package;
+import org.eclipse.uml2.uml.PackageableElement;
+
+import com.borkdominik.big.glsp.server.core.commands.semantic.BGCreateEdgeSemanticCommand;
+import com.borkdominik.big.glsp.server.core.model.BGTypeProvider;
+import com.borkdominik.big.glsp.server.elements.handler.operations.integrations.BGEMFEdgeOperationHandler;
+import com.borkdominik.big.glsp.uml.uml.commands.UMLCreateEdgeCommand;
+import com.google.inject.Inject;
+import com.google.inject.assistedinject.Assisted;
+
+public class ElementImportOperationHandler
+   extends BGEMFEdgeOperationHandler<ElementImport, Package, PackageableElement> {
+
+   @Inject
+   public ElementImportOperationHandler(@Assisted final Enumerator representation,
+      @Assisted final Set<BGTypeProvider> elementTypes) {
+      super(representation, elementTypes);
+
+   }
+
+   @Override
+   protected BGCreateEdgeSemanticCommand<ElementImport, Package, PackageableElement, ?> createSemanticCommand(
+      final CreateEdgeOperation operation, final Package source, final PackageableElement target) {
+      var argument = UMLCreateEdgeCommand.Argument
+         .<ElementImport, Package, PackageableElement> createEdgeArgumentBuilder()
+         .supplier((s, t) -> {
+            return s.createElementImport(t);
+         })
+         .build();
+
+      return new UMLCreateEdgeCommand<>(commandContext, source, target, argument);
+   }
+
+}

--- a/server/com.borkdominik.big.glsp.uml/src/main/java/com/borkdominik/big/glsp/uml/uml/elements/element_import/features/ElementImportPropertyProvider.java
+++ b/server/com.borkdominik.big.glsp.uml/src/main/java/com/borkdominik/big/glsp/uml/uml/elements/element_import/features/ElementImportPropertyProvider.java
@@ -1,0 +1,63 @@
+/********************************************************************************
+ * Copyright (c) 2024 borkdominik and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0, or the MIT License which is
+ * available at https://opensource.org/licenses/MIT.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR MIT
+ ********************************************************************************/
+package com.borkdominik.big.glsp.uml.uml.elements.element_import.features;
+
+import java.util.List;
+import java.util.Set;
+
+import org.eclipse.emf.common.command.Command;
+import org.eclipse.emf.common.util.Enumerator;
+import org.eclipse.uml2.uml.ElementImport;
+
+import com.borkdominik.big.glsp.server.core.model.BGTypeProvider;
+import com.borkdominik.big.glsp.server.features.property_palette.handler.BGUpdateElementPropertyAction;
+import com.borkdominik.big.glsp.server.features.property_palette.model.ElementPropertyBuilder;
+import com.borkdominik.big.glsp.server.features.property_palette.model.ElementPropertyItem;
+import com.borkdominik.big.glsp.server.features.property_palette.provider.integrations.BGEMFElementPropertyProvider;
+import com.borkdominik.big.glsp.uml.uml.commands.UMLUpdateElementCommand;
+import com.google.inject.Inject;
+import com.google.inject.assistedinject.Assisted;
+
+public class ElementImportPropertyProvider extends BGEMFElementPropertyProvider<ElementImport> {
+   public static final String ALIAS = "alias";
+
+   @Inject
+   public ElementImportPropertyProvider(@Assisted final Enumerator representation,
+      @Assisted final Set<BGTypeProvider> elementTypes) {
+      super(representation, elementTypes, Set.of(ALIAS));
+   }
+
+   @Override
+   public List<ElementPropertyItem> doProvide(final ElementImport element) {
+      var elementId = providerContext.idGenerator().getOrCreateId(element);
+      var builder = new ElementPropertyBuilder(elementId)
+         .text(ALIAS, "Alias", element.getAlias());
+
+      return builder.items();
+   }
+
+   @Override
+   public Command doHandle(final BGUpdateElementPropertyAction action, final ElementImport element) {
+      var value = action.getValue();
+      var argument = UMLUpdateElementCommand.Argument
+         .<ElementImport> updateElementArgumentBuilder()
+         .consumer(e -> {
+            switch (action.getPropertyId()) {
+               case ALIAS:
+                  e.setAlias(value);
+                  break;
+            }
+         })
+         .build();
+
+      return new UMLUpdateElementCommand<>(context, modelState.getSemanticModel(), element, argument);
+   }
+}

--- a/server/com.borkdominik.big.glsp.uml/src/main/java/com/borkdominik/big/glsp/uml/uml/elements/element_import/gmodel/ElementImportGModelMapper.java
+++ b/server/com.borkdominik.big.glsp.uml/src/main/java/com/borkdominik/big/glsp/uml/uml/elements/element_import/gmodel/ElementImportGModelMapper.java
@@ -1,0 +1,38 @@
+/********************************************************************************
+ * Copyright (c) 2021 borkdominik and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0, or the MIT License which is
+ * available at https://opensource.org/licenses/MIT.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR MIT
+ ********************************************************************************/
+package com.borkdominik.big.glsp.uml.uml.elements.element_import.gmodel;
+
+import java.util.Set;
+
+import org.eclipse.emf.common.util.Enumerator;
+import org.eclipse.glsp.graph.GEdge;
+import org.eclipse.uml2.uml.ElementImport;
+
+import com.borkdominik.big.glsp.server.core.model.BGTypeProvider;
+import com.borkdominik.big.glsp.server.elements.gmodel.BGEMFElementGModelMapper;
+import com.borkdominik.big.glsp.uml.uml.UMLTypes;
+import com.google.inject.Inject;
+import com.google.inject.assistedinject.Assisted;
+
+public final class ElementImportGModelMapper extends BGEMFElementGModelMapper<ElementImport, GEdge> {
+
+   @Inject
+   public ElementImportGModelMapper(@Assisted final Enumerator representation,
+      @Assisted final Set<BGTypeProvider> elementTypes) {
+      super(representation, elementTypes);
+   }
+
+   @Override
+   public GEdge map(final ElementImport source) {
+      return new GElementImportBuilder<>(gcmodelContext, source, UMLTypes.ELEMENT_IMPORT.prefix(representation))
+         .buildGModel();
+   }
+}

--- a/server/com.borkdominik.big.glsp.uml/src/main/java/com/borkdominik/big/glsp/uml/uml/elements/element_import/gmodel/GElementImportBuilder.java
+++ b/server/com.borkdominik.big.glsp.uml/src/main/java/com/borkdominik/big/glsp/uml/uml/elements/element_import/gmodel/GElementImportBuilder.java
@@ -1,0 +1,62 @@
+/********************************************************************************
+ * Copyright (c) 2023 borkdominik and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0, or the MIT License which is
+ * available at https://opensource.org/licenses/MIT.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR MIT
+ ********************************************************************************/
+package com.borkdominik.big.glsp.uml.uml.elements.element_import.gmodel;
+
+import java.util.List;
+
+import org.eclipse.emf.ecore.EObject;
+import org.eclipse.glsp.graph.GEdge;
+import org.eclipse.uml2.uml.ElementImport;
+
+import com.borkdominik.big.glsp.server.core.constants.BGCoreCSS;
+import com.borkdominik.big.glsp.server.sdk.cdk.GCModelContext;
+import com.borkdominik.big.glsp.server.sdk.cdk.base.GCProvider;
+import com.borkdominik.big.glsp.server.sdk.cdk.gmodel.GCModelList;
+import com.borkdominik.big.glsp.server.sdk.ui.builder.GCEdgeBuilder;
+import com.borkdominik.big.glsp.server.sdk.utils.StreamUtils;
+import com.borkdominik.big.glsp.uml.uml.elements.package_.utils.PackageVisibilityKindUtils;
+
+public class GElementImportBuilder<TOrigin extends ElementImport> extends GCEdgeBuilder<TOrigin> {
+
+   public GElementImportBuilder(final GCModelContext context, final TOrigin origin, final String type) {
+      super(context, origin, type);
+   }
+
+   @Override
+   public EObject source() {
+      return origin.getNearestPackage();
+   }
+
+   @Override
+   public EObject target() {
+      return origin.getImportedElement();
+   }
+
+   @Override
+   protected List<GCProvider> createComponentChildren(final GEdge gmodelRoot, final GCModelList<?, ?> componentRoot) {
+      var visibilityLabel = PackageVisibilityKindUtils.visiblityToLabel(origin.getVisibility());
+      var textBuilder = new StringBuilder(visibilityLabel);
+      var alias = origin.getAlias();
+      if (alias != null && alias.length() > 0) {
+         textBuilder.append(" as ");
+         textBuilder.append(alias);
+      }
+
+      return List.of(createCenteredLabel(textBuilder.toString()));
+   }
+
+   @Override
+   protected List<String> getRootGModelCss() {
+      return StreamUtils.concat(super.getDefaultCss(),
+         List.of(BGCoreCSS.EDGE_DASHED, BGCoreCSS.Marker.TENT.end()));
+   }
+
+}

--- a/server/com.borkdominik.big.glsp.uml/src/main/java/com/borkdominik/big/glsp/uml/uml/elements/extend/ExtendConfiguration.java
+++ b/server/com.borkdominik.big.glsp.uml/src/main/java/com/borkdominik/big/glsp/uml/uml/elements/extend/ExtendConfiguration.java
@@ -1,0 +1,48 @@
+/********************************************************************************
+ * Copyright (c) 2023 borkdominik and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0, or the MIT License which is
+ * available at https://opensource.org/licenses/MIT.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR MIT
+ ********************************************************************************/
+package com.borkdominik.big.glsp.uml.uml.elements.extend;
+
+import java.util.Map;
+import java.util.Set;
+
+import org.eclipse.emf.common.util.Enumerator;
+import org.eclipse.emf.ecore.EClass;
+import org.eclipse.glsp.graph.GraphPackage;
+import org.eclipse.glsp.server.types.EdgeTypeHint;
+
+import com.borkdominik.big.glsp.server.core.model.BGTypeProvider;
+import com.borkdominik.big.glsp.server.elements.configuration.base.BGBaseEdgeConfiguration;
+import com.borkdominik.big.glsp.uml.uml.UMLTypes;
+import com.google.inject.Inject;
+import com.google.inject.assistedinject.Assisted;
+
+public class ExtendConfiguration extends BGBaseEdgeConfiguration {
+   protected final String typeId = UMLTypes.EXTEND.prefix(representation);
+
+   @Inject
+   public ExtendConfiguration(@Assisted final Enumerator representation,
+      @Assisted final Set<BGTypeProvider> elementTypes) {
+      super(representation, elementTypes);
+   }
+
+   @Override
+   public Map<String, EClass> getTypeMappings() { return Map.of(typeId, GraphPackage.Literals.GEDGE); }
+
+   @Override
+   public Set<EdgeTypeHint> getEdgeTypeHints() {
+      return Set.of(
+         new EdgeTypeHint(typeId, true, true, true,
+            elementConfig().existingConfigurationTypeIds(Set.of(
+               UMLTypes.USE_CASE)),
+            elementConfig().existingConfigurationTypeIds(Set.of(
+               UMLTypes.USE_CASE))));
+   }
+}

--- a/server/com.borkdominik.big.glsp.uml/src/main/java/com/borkdominik/big/glsp/uml/uml/elements/extend/ExtendElementManifest.java
+++ b/server/com.borkdominik.big.glsp.uml/src/main/java/com/borkdominik/big/glsp/uml/uml/elements/extend/ExtendElementManifest.java
@@ -1,0 +1,34 @@
+/********************************************************************************
+ * Copyright (c) 2023 borkdominik and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0, or the MIT License which is
+ * available at https://opensource.org/licenses/MIT.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR MIT
+ ********************************************************************************/
+package com.borkdominik.big.glsp.uml.uml.elements.extend;
+
+import java.util.Set;
+
+import com.borkdominik.big.glsp.server.core.manifest.BGRepresentationManifest;
+import com.borkdominik.big.glsp.server.elements.manifest.integrations.BGEMFEdgeElementManifest;
+import com.borkdominik.big.glsp.server.features.property_palette.BGPropertyPaletteContribution;
+import com.borkdominik.big.glsp.uml.uml.UMLTypes;
+import com.borkdominik.big.glsp.uml.uml.elements.extend.gmodel.ExtendGModelMapper;
+
+public class ExtendElementManifest extends BGEMFEdgeElementManifest {
+   public ExtendElementManifest(final BGRepresentationManifest manifest) {
+      super(manifest, Set.of(UMLTypes.EXTEND));
+   }
+
+   @Override
+   protected void configureElement() {
+      bindGModelMapper(ExtendGModelMapper.class);
+      bindConfiguration(ExtendConfiguration.class);
+      bindCreateHandler(ExtendOperationHandler.class);
+      bindPropertyPalette(BGPropertyPaletteContribution.Options.builder()
+         .propertyProviders(Set.of()));
+   }
+}

--- a/server/com.borkdominik.big.glsp.uml/src/main/java/com/borkdominik/big/glsp/uml/uml/elements/extend/ExtendOperationHandler.java
+++ b/server/com.borkdominik.big.glsp.uml/src/main/java/com/borkdominik/big/glsp/uml/uml/elements/extend/ExtendOperationHandler.java
@@ -1,0 +1,49 @@
+/********************************************************************************
+ * Copyright (c) 2023 borkdominik and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0, or the MIT License which is
+ * available at https://opensource.org/licenses/MIT.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR MIT
+ ********************************************************************************/
+package com.borkdominik.big.glsp.uml.uml.elements.extend;
+
+import java.util.Set;
+
+import org.eclipse.emf.common.util.Enumerator;
+import org.eclipse.glsp.server.operations.CreateEdgeOperation;
+import org.eclipse.uml2.uml.Extend;
+import org.eclipse.uml2.uml.UseCase;
+
+import com.borkdominik.big.glsp.server.core.commands.semantic.BGCreateEdgeSemanticCommand;
+import com.borkdominik.big.glsp.server.core.model.BGTypeProvider;
+import com.borkdominik.big.glsp.server.elements.handler.operations.integrations.BGEMFEdgeOperationHandler;
+import com.borkdominik.big.glsp.uml.uml.commands.UMLCreateEdgeCommand;
+import com.google.inject.Inject;
+import com.google.inject.assistedinject.Assisted;
+
+public class ExtendOperationHandler extends BGEMFEdgeOperationHandler<Extend, UseCase, UseCase> {
+
+   @Inject
+   public ExtendOperationHandler(@Assisted final Enumerator representation,
+      @Assisted final Set<BGTypeProvider> elementTypes) {
+      super(representation, elementTypes);
+
+   }
+
+   @Override
+   protected BGCreateEdgeSemanticCommand<Extend, UseCase, UseCase, ?> createSemanticCommand(
+      final CreateEdgeOperation operation, final UseCase source, final UseCase target) {
+      var argument = UMLCreateEdgeCommand.Argument
+         .<Extend, UseCase, UseCase> createEdgeArgumentBuilder()
+         .supplier((s, t) -> {
+            return s.createExtend(null, t);
+         })
+         .build();
+
+      return new UMLCreateEdgeCommand<>(commandContext, source, target, argument);
+   }
+
+}

--- a/server/com.borkdominik.big.glsp.uml/src/main/java/com/borkdominik/big/glsp/uml/uml/elements/extend/gmodel/ExtendGModelMapper.java
+++ b/server/com.borkdominik.big.glsp.uml/src/main/java/com/borkdominik/big/glsp/uml/uml/elements/extend/gmodel/ExtendGModelMapper.java
@@ -1,0 +1,37 @@
+/********************************************************************************
+ * Copyright (c) 2021 borkdominik and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0, or the MIT License which is
+ * available at https://opensource.org/licenses/MIT.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR MIT
+ ********************************************************************************/
+package com.borkdominik.big.glsp.uml.uml.elements.extend.gmodel;
+
+import java.util.Set;
+
+import org.eclipse.emf.common.util.Enumerator;
+import org.eclipse.glsp.graph.GEdge;
+import org.eclipse.uml2.uml.Extend;
+
+import com.borkdominik.big.glsp.server.core.model.BGTypeProvider;
+import com.borkdominik.big.glsp.server.elements.gmodel.BGEMFElementGModelMapper;
+import com.borkdominik.big.glsp.uml.uml.UMLTypes;
+import com.google.inject.Inject;
+import com.google.inject.assistedinject.Assisted;
+
+public final class ExtendGModelMapper extends BGEMFElementGModelMapper<Extend, GEdge> {
+
+   @Inject
+   public ExtendGModelMapper(@Assisted final Enumerator representation,
+      @Assisted final Set<BGTypeProvider> elementTypes) {
+      super(representation, elementTypes);
+   }
+
+   @Override
+   public GEdge map(final Extend source) {
+      return new GExtendBuilder<>(gcmodelContext, source, UMLTypes.EXTEND.prefix(representation)).buildGModel();
+   }
+}

--- a/server/com.borkdominik.big.glsp.uml/src/main/java/com/borkdominik/big/glsp/uml/uml/elements/extend/gmodel/GExtendBuilder.java
+++ b/server/com.borkdominik.big.glsp.uml/src/main/java/com/borkdominik/big/glsp/uml/uml/elements/extend/gmodel/GExtendBuilder.java
@@ -1,0 +1,53 @@
+/********************************************************************************
+ * Copyright (c) 2023 borkdominik and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0, or the MIT License which is
+ * available at https://opensource.org/licenses/MIT.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR MIT
+ ********************************************************************************/
+package com.borkdominik.big.glsp.uml.uml.elements.extend.gmodel;
+
+import java.util.List;
+
+import org.eclipse.emf.ecore.EObject;
+import org.eclipse.glsp.graph.GEdge;
+import org.eclipse.uml2.uml.Extend;
+
+import com.borkdominik.big.glsp.server.core.constants.BGCoreCSS;
+import com.borkdominik.big.glsp.server.core.constants.BGQuotationMark;
+import com.borkdominik.big.glsp.server.sdk.cdk.GCModelContext;
+import com.borkdominik.big.glsp.server.sdk.cdk.base.GCProvider;
+import com.borkdominik.big.glsp.server.sdk.cdk.gmodel.GCModelList;
+import com.borkdominik.big.glsp.server.sdk.ui.builder.GCEdgeBuilder;
+import com.borkdominik.big.glsp.server.sdk.utils.StreamUtils;
+
+public class GExtendBuilder<TOrigin extends Extend> extends GCEdgeBuilder<TOrigin> {
+
+   public GExtendBuilder(final GCModelContext context, final TOrigin origin, final String type) {
+      super(context, origin, type);
+   }
+
+   @Override
+   public EObject source() {
+      return origin.getExtension();
+   }
+
+   @Override
+   public EObject target() {
+      return origin.getExtendedCase();
+   }
+
+   @Override
+   protected List<String> getRootGModelCss() {
+      return StreamUtils.concat(super.getDefaultCss(), List.of(BGCoreCSS.EDGE_DASHED, BGCoreCSS.Marker.TENT.end()));
+   }
+
+   @Override
+   protected List<GCProvider> createComponentChildren(final GEdge gmodelRoot, final GCModelList<?, ?> componentRoot) {
+      return List.of(createCenteredLabel(BGQuotationMark.quoteDoubleAngle("extend")));
+   }
+
+}

--- a/server/com.borkdominik.big.glsp.uml/src/main/java/com/borkdominik/big/glsp/uml/uml/elements/include/IncludeConfiguration.java
+++ b/server/com.borkdominik.big.glsp.uml/src/main/java/com/borkdominik/big/glsp/uml/uml/elements/include/IncludeConfiguration.java
@@ -1,0 +1,48 @@
+/********************************************************************************
+ * Copyright (c) 2023 borkdominik and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0, or the MIT License which is
+ * available at https://opensource.org/licenses/MIT.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR MIT
+ ********************************************************************************/
+package com.borkdominik.big.glsp.uml.uml.elements.include;
+
+import java.util.Map;
+import java.util.Set;
+
+import org.eclipse.emf.common.util.Enumerator;
+import org.eclipse.emf.ecore.EClass;
+import org.eclipse.glsp.graph.GraphPackage;
+import org.eclipse.glsp.server.types.EdgeTypeHint;
+
+import com.borkdominik.big.glsp.server.core.model.BGTypeProvider;
+import com.borkdominik.big.glsp.server.elements.configuration.base.BGBaseEdgeConfiguration;
+import com.borkdominik.big.glsp.uml.uml.UMLTypes;
+import com.google.inject.Inject;
+import com.google.inject.assistedinject.Assisted;
+
+public class IncludeConfiguration extends BGBaseEdgeConfiguration {
+   protected final String typeId = UMLTypes.INCLUDE.prefix(representation);
+
+   @Inject
+   public IncludeConfiguration(@Assisted final Enumerator representation,
+      @Assisted final Set<BGTypeProvider> elementTypes) {
+      super(representation, elementTypes);
+   }
+
+   @Override
+   public Map<String, EClass> getTypeMappings() { return Map.of(typeId, GraphPackage.Literals.GEDGE); }
+
+   @Override
+   public Set<EdgeTypeHint> getEdgeTypeHints() {
+      return Set.of(
+         new EdgeTypeHint(typeId, true, true, true,
+            elementConfig().existingConfigurationTypeIds(Set.of(
+               UMLTypes.USE_CASE)),
+            elementConfig().existingConfigurationTypeIds(Set.of(
+               UMLTypes.USE_CASE))));
+   }
+}

--- a/server/com.borkdominik.big.glsp.uml/src/main/java/com/borkdominik/big/glsp/uml/uml/elements/include/IncludeElementManifest.java
+++ b/server/com.borkdominik.big.glsp.uml/src/main/java/com/borkdominik/big/glsp/uml/uml/elements/include/IncludeElementManifest.java
@@ -1,0 +1,34 @@
+/********************************************************************************
+ * Copyright (c) 2023 borkdominik and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0, or the MIT License which is
+ * available at https://opensource.org/licenses/MIT.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR MIT
+ ********************************************************************************/
+package com.borkdominik.big.glsp.uml.uml.elements.include;
+
+import java.util.Set;
+
+import com.borkdominik.big.glsp.server.core.manifest.BGRepresentationManifest;
+import com.borkdominik.big.glsp.server.elements.manifest.integrations.BGEMFEdgeElementManifest;
+import com.borkdominik.big.glsp.server.features.property_palette.BGPropertyPaletteContribution;
+import com.borkdominik.big.glsp.uml.uml.UMLTypes;
+import com.borkdominik.big.glsp.uml.uml.elements.include.gmodel.IncludeGModelMapper;
+
+public class IncludeElementManifest extends BGEMFEdgeElementManifest {
+   public IncludeElementManifest(final BGRepresentationManifest manifest) {
+      super(manifest, Set.of(UMLTypes.INCLUDE));
+   }
+
+   @Override
+   protected void configureElement() {
+      bindGModelMapper(IncludeGModelMapper.class);
+      bindConfiguration(IncludeConfiguration.class);
+      bindCreateHandler(IncludeOperationHandler.class);
+      bindPropertyPalette(BGPropertyPaletteContribution.Options.builder()
+         .propertyProviders(Set.of()));
+   }
+}

--- a/server/com.borkdominik.big.glsp.uml/src/main/java/com/borkdominik/big/glsp/uml/uml/elements/include/IncludeOperationHandler.java
+++ b/server/com.borkdominik.big.glsp.uml/src/main/java/com/borkdominik/big/glsp/uml/uml/elements/include/IncludeOperationHandler.java
@@ -1,0 +1,49 @@
+/********************************************************************************
+ * Copyright (c) 2023 borkdominik and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0, or the MIT License which is
+ * available at https://opensource.org/licenses/MIT.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR MIT
+ ********************************************************************************/
+package com.borkdominik.big.glsp.uml.uml.elements.include;
+
+import java.util.Set;
+
+import org.eclipse.emf.common.util.Enumerator;
+import org.eclipse.glsp.server.operations.CreateEdgeOperation;
+import org.eclipse.uml2.uml.Include;
+import org.eclipse.uml2.uml.UseCase;
+
+import com.borkdominik.big.glsp.server.core.commands.semantic.BGCreateEdgeSemanticCommand;
+import com.borkdominik.big.glsp.server.core.model.BGTypeProvider;
+import com.borkdominik.big.glsp.server.elements.handler.operations.integrations.BGEMFEdgeOperationHandler;
+import com.borkdominik.big.glsp.uml.uml.commands.UMLCreateEdgeCommand;
+import com.google.inject.Inject;
+import com.google.inject.assistedinject.Assisted;
+
+public class IncludeOperationHandler extends BGEMFEdgeOperationHandler<Include, UseCase, UseCase> {
+
+   @Inject
+   public IncludeOperationHandler(@Assisted final Enumerator representation,
+      @Assisted final Set<BGTypeProvider> elementTypes) {
+      super(representation, elementTypes);
+
+   }
+
+   @Override
+   protected BGCreateEdgeSemanticCommand<Include, UseCase, UseCase, ?> createSemanticCommand(
+      final CreateEdgeOperation operation, final UseCase source, final UseCase target) {
+      var argument = UMLCreateEdgeCommand.Argument
+         .<Include, UseCase, UseCase> createEdgeArgumentBuilder()
+         .supplier((s, t) -> {
+            return s.createInclude(null, t);
+         })
+         .build();
+
+      return new UMLCreateEdgeCommand<>(commandContext, source, target, argument);
+   }
+
+}

--- a/server/com.borkdominik.big.glsp.uml/src/main/java/com/borkdominik/big/glsp/uml/uml/elements/include/gmodel/GIncludeBuilder.java
+++ b/server/com.borkdominik.big.glsp.uml/src/main/java/com/borkdominik/big/glsp/uml/uml/elements/include/gmodel/GIncludeBuilder.java
@@ -1,0 +1,53 @@
+/********************************************************************************
+ * Copyright (c) 2023 borkdominik and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0, or the MIT License which is
+ * available at https://opensource.org/licenses/MIT.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR MIT
+ ********************************************************************************/
+package com.borkdominik.big.glsp.uml.uml.elements.include.gmodel;
+
+import java.util.List;
+
+import org.eclipse.emf.ecore.EObject;
+import org.eclipse.glsp.graph.GEdge;
+import org.eclipse.uml2.uml.Include;
+
+import com.borkdominik.big.glsp.server.core.constants.BGCoreCSS;
+import com.borkdominik.big.glsp.server.core.constants.BGQuotationMark;
+import com.borkdominik.big.glsp.server.sdk.cdk.GCModelContext;
+import com.borkdominik.big.glsp.server.sdk.cdk.base.GCProvider;
+import com.borkdominik.big.glsp.server.sdk.cdk.gmodel.GCModelList;
+import com.borkdominik.big.glsp.server.sdk.ui.builder.GCEdgeBuilder;
+import com.borkdominik.big.glsp.server.sdk.utils.StreamUtils;
+
+public class GIncludeBuilder<TOrigin extends Include> extends GCEdgeBuilder<TOrigin> {
+
+   public GIncludeBuilder(final GCModelContext context, final TOrigin origin, final String type) {
+      super(context, origin, type);
+   }
+
+   @Override
+   public EObject source() {
+      return origin.getIncludingCase();
+   }
+
+   @Override
+   public EObject target() {
+      return origin.getAddition();
+   }
+
+   @Override
+   protected List<String> getRootGModelCss() {
+      return StreamUtils.concat(super.getDefaultCss(), List.of(BGCoreCSS.EDGE_DASHED, BGCoreCSS.Marker.TENT.end()));
+   }
+
+   @Override
+   protected List<GCProvider> createComponentChildren(final GEdge gmodelRoot, final GCModelList<?, ?> componentRoot) {
+      return List.of(createCenteredLabel(BGQuotationMark.quoteDoubleAngle("include")));
+   }
+
+}

--- a/server/com.borkdominik.big.glsp.uml/src/main/java/com/borkdominik/big/glsp/uml/uml/elements/include/gmodel/IncludeGModelMapper.java
+++ b/server/com.borkdominik.big.glsp.uml/src/main/java/com/borkdominik/big/glsp/uml/uml/elements/include/gmodel/IncludeGModelMapper.java
@@ -1,0 +1,37 @@
+/********************************************************************************
+ * Copyright (c) 2021 borkdominik and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0, or the MIT License which is
+ * available at https://opensource.org/licenses/MIT.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR MIT
+ ********************************************************************************/
+package com.borkdominik.big.glsp.uml.uml.elements.include.gmodel;
+
+import java.util.Set;
+
+import org.eclipse.emf.common.util.Enumerator;
+import org.eclipse.glsp.graph.GEdge;
+import org.eclipse.uml2.uml.Include;
+
+import com.borkdominik.big.glsp.server.core.model.BGTypeProvider;
+import com.borkdominik.big.glsp.server.elements.gmodel.BGEMFElementGModelMapper;
+import com.borkdominik.big.glsp.uml.uml.UMLTypes;
+import com.google.inject.Inject;
+import com.google.inject.assistedinject.Assisted;
+
+public final class IncludeGModelMapper extends BGEMFElementGModelMapper<Include, GEdge> {
+
+   @Inject
+   public IncludeGModelMapper(@Assisted final Enumerator representation,
+      @Assisted final Set<BGTypeProvider> elementTypes) {
+      super(representation, elementTypes);
+   }
+
+   @Override
+   public GEdge map(final Include source) {
+      return new GIncludeBuilder<>(gcmodelContext, source, UMLTypes.INCLUDE.prefix(representation)).buildGModel();
+   }
+}

--- a/server/com.borkdominik.big.glsp.uml/src/main/java/com/borkdominik/big/glsp/uml/uml/elements/information_flow/InformationFlowConfiguration.java
+++ b/server/com.borkdominik.big.glsp.uml/src/main/java/com/borkdominik/big/glsp/uml/uml/elements/information_flow/InformationFlowConfiguration.java
@@ -1,0 +1,48 @@
+/********************************************************************************
+ * Copyright (c) 2023 borkdominik and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0, or the MIT License which is
+ * available at https://opensource.org/licenses/MIT.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR MIT
+ ********************************************************************************/
+package com.borkdominik.big.glsp.uml.uml.elements.information_flow;
+
+import java.util.Map;
+import java.util.Set;
+
+import org.eclipse.emf.common.util.Enumerator;
+import org.eclipse.emf.ecore.EClass;
+import org.eclipse.glsp.graph.GraphPackage;
+import org.eclipse.glsp.server.types.EdgeTypeHint;
+
+import com.borkdominik.big.glsp.server.core.model.BGTypeProvider;
+import com.borkdominik.big.glsp.server.elements.configuration.base.BGBaseEdgeConfiguration;
+import com.borkdominik.big.glsp.uml.uml.UMLTypes;
+import com.google.inject.Inject;
+import com.google.inject.assistedinject.Assisted;
+
+public class InformationFlowConfiguration extends BGBaseEdgeConfiguration {
+   protected final String typeId = UMLTypes.INFORMATION_FLOW.prefix(representation);
+
+   @Inject
+   public InformationFlowConfiguration(@Assisted final Enumerator representation,
+      @Assisted final Set<BGTypeProvider> elementTypes) {
+      super(representation, elementTypes);
+   }
+
+   @Override
+   public Map<String, EClass> getTypeMappings() { return Map.of(typeId, GraphPackage.Literals.GEDGE); }
+
+   @Override
+   public Set<EdgeTypeHint> getEdgeTypeHints() {
+      return Set.of(
+         new EdgeTypeHint(typeId, true, true, true,
+            elementConfig().existingConfigurationTypeIds(Set.of(
+               UMLTypes.ACTOR, UMLTypes.CLASS)),
+            elementConfig().existingConfigurationTypeIds(Set.of(
+               UMLTypes.CLASS, UMLTypes.ACTOR))));
+   }
+}

--- a/server/com.borkdominik.big.glsp.uml/src/main/java/com/borkdominik/big/glsp/uml/uml/elements/information_flow/InformationFlowElementManifest.java
+++ b/server/com.borkdominik.big.glsp.uml/src/main/java/com/borkdominik/big/glsp/uml/uml/elements/information_flow/InformationFlowElementManifest.java
@@ -1,0 +1,37 @@
+/********************************************************************************
+ * Copyright (c) 2023 borkdominik and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0, or the MIT License which is
+ * available at https://opensource.org/licenses/MIT.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR MIT
+ ********************************************************************************/
+package com.borkdominik.big.glsp.uml.uml.elements.information_flow;
+
+import java.util.Set;
+
+import com.borkdominik.big.glsp.server.core.manifest.BGRepresentationManifest;
+import com.borkdominik.big.glsp.server.elements.manifest.integrations.BGEMFEdgeElementManifest;
+import com.borkdominik.big.glsp.server.features.property_palette.BGPropertyPaletteContribution;
+import com.borkdominik.big.glsp.uml.uml.UMLTypes;
+import com.borkdominik.big.glsp.uml.uml.elements.information_flow.gmodel.InformationFlowGModelMapper;
+import com.borkdominik.big.glsp.uml.uml.elements.named_element.NamedElementLabelEditHandler;
+import com.borkdominik.big.glsp.uml.uml.elements.named_element.NamedElementPropertyProvider;
+
+public class InformationFlowElementManifest extends BGEMFEdgeElementManifest {
+   public InformationFlowElementManifest(final BGRepresentationManifest manifest) {
+      super(manifest, Set.of(UMLTypes.INFORMATION_FLOW));
+   }
+
+   @Override
+   protected void configureElement() {
+      bindGModelMapper(InformationFlowGModelMapper.class);
+      bindConfiguration(InformationFlowConfiguration.class);
+      bindCreateHandler(InformationFlowOperationHandler.class);
+      bindEditLabel(Set.of(NamedElementLabelEditHandler.class));
+      bindPropertyPalette(BGPropertyPaletteContribution.Options.builder()
+         .propertyProviders(Set.of(NamedElementPropertyProvider.class)));
+   }
+}

--- a/server/com.borkdominik.big.glsp.uml/src/main/java/com/borkdominik/big/glsp/uml/uml/elements/information_flow/InformationFlowOperationHandler.java
+++ b/server/com.borkdominik.big.glsp.uml/src/main/java/com/borkdominik/big/glsp/uml/uml/elements/information_flow/InformationFlowOperationHandler.java
@@ -1,0 +1,55 @@
+/********************************************************************************
+ * Copyright (c) 2023 borkdominik and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0, or the MIT License which is
+ * available at https://opensource.org/licenses/MIT.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR MIT
+ ********************************************************************************/
+package com.borkdominik.big.glsp.uml.uml.elements.information_flow;
+
+import java.util.Set;
+
+import org.eclipse.emf.common.util.Enumerator;
+import org.eclipse.glsp.server.operations.CreateEdgeOperation;
+import org.eclipse.uml2.uml.InformationFlow;
+import org.eclipse.uml2.uml.NamedElement;
+import org.eclipse.uml2.uml.UMLFactory;
+
+import com.borkdominik.big.glsp.server.core.commands.semantic.BGCreateEdgeSemanticCommand;
+import com.borkdominik.big.glsp.server.core.model.BGTypeProvider;
+import com.borkdominik.big.glsp.server.elements.handler.operations.integrations.BGEMFEdgeOperationHandler;
+import com.borkdominik.big.glsp.uml.uml.commands.UMLCreateEdgeCommand;
+import com.google.inject.Inject;
+import com.google.inject.assistedinject.Assisted;
+
+public class InformationFlowOperationHandler
+   extends BGEMFEdgeOperationHandler<InformationFlow, NamedElement, NamedElement> {
+
+   @Inject
+   public InformationFlowOperationHandler(@Assisted final Enumerator representation,
+      @Assisted final Set<BGTypeProvider> elementTypes) {
+      super(representation, elementTypes);
+
+   }
+
+   @Override
+   protected BGCreateEdgeSemanticCommand<InformationFlow, NamedElement, NamedElement, ?> createSemanticCommand(
+      final CreateEdgeOperation operation, final NamedElement source, final NamedElement target) {
+      var argument = UMLCreateEdgeCommand.Argument
+         .<InformationFlow, NamedElement, NamedElement> createEdgeArgumentBuilder()
+         .supplier((s, t) -> {
+            var informationFlow = UMLFactory.eINSTANCE.createInformationFlow();
+            informationFlow.getInformationSources().add(source);
+            informationFlow.getInformationTargets().add(target);
+            source.getNearestPackage().getPackagedElements().add(informationFlow);
+            return informationFlow;
+         })
+         .build();
+
+      return new UMLCreateEdgeCommand<>(commandContext, source, target, argument);
+   }
+
+}

--- a/server/com.borkdominik.big.glsp.uml/src/main/java/com/borkdominik/big/glsp/uml/uml/elements/information_flow/gmodel/GInformationFlowBuilder.java
+++ b/server/com.borkdominik.big.glsp.uml/src/main/java/com/borkdominik/big/glsp/uml/uml/elements/information_flow/gmodel/GInformationFlowBuilder.java
@@ -1,0 +1,70 @@
+/********************************************************************************
+ * Copyright (c) 2023 borkdominik and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0, or the MIT License which is
+ * available at https://opensource.org/licenses/MIT.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR MIT
+ ********************************************************************************/
+package com.borkdominik.big.glsp.uml.uml.elements.information_flow.gmodel;
+
+import java.util.List;
+
+import org.eclipse.emf.ecore.EObject;
+import org.eclipse.glsp.graph.GEdge;
+import org.eclipse.glsp.graph.builder.impl.GEdgePlacementBuilder;
+import org.eclipse.glsp.graph.util.GConstants;
+import org.eclipse.uml2.uml.InformationFlow;
+
+import com.borkdominik.big.glsp.server.core.constants.BGCoreCSS;
+import com.borkdominik.big.glsp.server.core.constants.BGQuotationMark;
+import com.borkdominik.big.glsp.server.sdk.cdk.GCModelContext;
+import com.borkdominik.big.glsp.server.sdk.cdk.base.GCProvider;
+import com.borkdominik.big.glsp.server.sdk.cdk.gmodel.GCModelList;
+import com.borkdominik.big.glsp.server.sdk.ui.builder.GCEdgeBuilder;
+import com.borkdominik.big.glsp.server.sdk.ui.components.label.GCNameLabel;
+import com.borkdominik.big.glsp.server.sdk.utils.StreamUtils;
+
+public class GInformationFlowBuilder<TOrigin extends InformationFlow> extends GCEdgeBuilder<TOrigin> {
+
+   public GInformationFlowBuilder(final GCModelContext context, final TOrigin origin, final String type) {
+      super(context, origin, type);
+   }
+
+   @Override
+   public EObject source() {
+      return origin.getInformationSources().get(0);
+   }
+
+   @Override
+   public EObject target() {
+      return origin.getInformationTargets().get(0);
+   }
+
+   @Override
+   protected List<String> getRootGModelCss() {
+      return StreamUtils.concat(super.getDefaultCss(), List.of(BGCoreCSS.EDGE_DASHED, BGCoreCSS.Marker.TENT.end()));
+   }
+
+   @Override
+   protected List<GCProvider> createComponentChildren(final GEdge gmodelRoot, final GCModelList<?, ?> componentRoot) {
+      var nameLabelOptions = GCNameLabel.Options.builder()
+         .label(origin.getName())
+         .clearCss()
+         .css(BGCoreCSS.TEXT_HIGHLIGHT)
+         .edgePlacement(new GEdgePlacementBuilder()
+            .side(GConstants.EdgeSide.BOTTOM)
+            .position(0.5d)
+            .offset(10d)
+            .rotate(true)
+            .build())
+         .build();
+
+      var nameLabel = new GCNameLabel(context, origin, nameLabelOptions);
+
+      return List.of(createCenteredLabel(BGQuotationMark.quoteDoubleAngle("flow")), nameLabel);
+   }
+
+}

--- a/server/com.borkdominik.big.glsp.uml/src/main/java/com/borkdominik/big/glsp/uml/uml/elements/information_flow/gmodel/InformationFlowGModelMapper.java
+++ b/server/com.borkdominik.big.glsp.uml/src/main/java/com/borkdominik/big/glsp/uml/uml/elements/information_flow/gmodel/InformationFlowGModelMapper.java
@@ -1,0 +1,38 @@
+/********************************************************************************
+ * Copyright (c) 2021 borkdominik and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0, or the MIT License which is
+ * available at https://opensource.org/licenses/MIT.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR MIT
+ ********************************************************************************/
+package com.borkdominik.big.glsp.uml.uml.elements.information_flow.gmodel;
+
+import java.util.Set;
+
+import org.eclipse.emf.common.util.Enumerator;
+import org.eclipse.glsp.graph.GEdge;
+import org.eclipse.uml2.uml.InformationFlow;
+
+import com.borkdominik.big.glsp.server.core.model.BGTypeProvider;
+import com.borkdominik.big.glsp.server.elements.gmodel.BGEMFElementGModelMapper;
+import com.borkdominik.big.glsp.uml.uml.UMLTypes;
+import com.google.inject.Inject;
+import com.google.inject.assistedinject.Assisted;
+
+public final class InformationFlowGModelMapper extends BGEMFElementGModelMapper<InformationFlow, GEdge> {
+
+   @Inject
+   public InformationFlowGModelMapper(@Assisted final Enumerator representation,
+      @Assisted final Set<BGTypeProvider> elementTypes) {
+      super(representation, elementTypes);
+   }
+
+   @Override
+   public GEdge map(final InformationFlow source) {
+      return new GInformationFlowBuilder<>(gcmodelContext, source, UMLTypes.INFORMATION_FLOW.prefix(representation))
+         .buildGModel();
+   }
+}

--- a/server/com.borkdominik.big.glsp.uml/src/main/java/com/borkdominik/big/glsp/uml/uml/elements/package_import/utils/PackageImportPropertyPaletteUtils.java
+++ b/server/com.borkdominik.big.glsp.uml/src/main/java/com/borkdominik/big/glsp/uml/uml/elements/package_import/utils/PackageImportPropertyPaletteUtils.java
@@ -29,7 +29,7 @@ public class PackageImportPropertyPaletteUtils {
             var p = v.getImportedPackage();
             var label = String.format("<Package Import> %s", p.getName());
             return ElementReferencePropertyItem.Reference.builder()
-               .elementId(idGenerator.getOrCreateId(v))
+               .elementId(idGenerator.getOrCreateId(p))
                .label(label)
                .name(p.getName())
                .build();

--- a/server/com.borkdominik.big.glsp.uml/src/main/java/com/borkdominik/big/glsp/uml/uml/elements/package_merge/utils/PackageMergePropertyPaletteUtils.java
+++ b/server/com.borkdominik.big.glsp.uml/src/main/java/com/borkdominik/big/glsp/uml/uml/elements/package_merge/utils/PackageMergePropertyPaletteUtils.java
@@ -26,7 +26,7 @@ public class PackageMergePropertyPaletteUtils {
             var p = v.getMergedPackage();
             var label = String.format("<Package Merge> %s", p.getName());
             return ElementReferencePropertyItem.Reference.builder()
-               .elementId(idGenerator.getOrCreateId(v))
+               .elementId(idGenerator.getOrCreateId(p))
                .label(label)
                .name(p.getName())
                .build();

--- a/server/com.borkdominik.big.glsp.uml/src/main/java/com/borkdominik/big/glsp/uml/uml/elements/use_case/UseCaseConfiguration.java
+++ b/server/com.borkdominik.big.glsp.uml/src/main/java/com/borkdominik/big/glsp/uml/uml/elements/use_case/UseCaseConfiguration.java
@@ -1,0 +1,50 @@
+/********************************************************************************
+ * Copyright (c) 2023 borkdominik and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0, or the MIT License which is
+ * available at https://opensource.org/licenses/MIT.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR MIT
+ ********************************************************************************/
+package com.borkdominik.big.glsp.uml.uml.elements.use_case;
+
+import java.util.Map;
+import java.util.Set;
+
+import org.eclipse.emf.common.util.Enumerator;
+import org.eclipse.emf.ecore.EClass;
+import org.eclipse.glsp.graph.GraphPackage;
+import org.eclipse.glsp.server.types.ShapeTypeHint;
+
+import com.borkdominik.big.glsp.server.core.model.BGTypeProvider;
+import com.borkdominik.big.glsp.server.elements.configuration.base.BGBaseNodeConfiguration;
+import com.borkdominik.big.glsp.uml.uml.UMLTypes;
+import com.google.inject.Inject;
+import com.google.inject.assistedinject.Assisted;
+
+public class UseCaseConfiguration extends BGBaseNodeConfiguration {
+   protected final String typeId = UMLTypes.USE_CASE.prefix(representation);
+
+   @Inject
+   public UseCaseConfiguration(@Assisted final Enumerator representation,
+      @Assisted final Set<BGTypeProvider> elementTypes) {
+      super(representation, elementTypes);
+   }
+
+   @Override
+   public Map<String, EClass> getTypeMappings() { return Map.of(
+      typeId, GraphPackage.Literals.GNODE); }
+
+   @Override
+   public Set<String> getGraphContainableElements() { return Set.of(typeId); }
+
+   @Override
+   public Set<ShapeTypeHint> getShapeTypeHints() {
+      return Set.of(
+         new ShapeTypeHint(typeId, true, true, true, false,
+            elementConfig().existingConfigurationTypeIds(Set.of())));
+   }
+
+}

--- a/server/com.borkdominik.big.glsp.uml/src/main/java/com/borkdominik/big/glsp/uml/uml/elements/use_case/UseCaseElementManifest.java
+++ b/server/com.borkdominik.big.glsp.uml/src/main/java/com/borkdominik/big/glsp/uml/uml/elements/use_case/UseCaseElementManifest.java
@@ -1,0 +1,38 @@
+/********************************************************************************
+ * Copyright (c) 2023 borkdominik and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0, or the MIT License which is
+ * available at https://opensource.org/licenses/MIT.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR MIT
+ ********************************************************************************/
+package com.borkdominik.big.glsp.uml.uml.elements.use_case;
+
+import java.util.Set;
+
+import com.borkdominik.big.glsp.server.core.manifest.BGRepresentationManifest;
+import com.borkdominik.big.glsp.server.elements.manifest.integrations.BGEMFNodeElementManifest;
+import com.borkdominik.big.glsp.server.features.property_palette.BGPropertyPaletteContribution;
+import com.borkdominik.big.glsp.uml.uml.UMLTypes;
+import com.borkdominik.big.glsp.uml.uml.elements.named_element.NamedElementLabelEditHandler;
+import com.borkdominik.big.glsp.uml.uml.elements.named_element.NamedElementPropertyProvider;
+import com.borkdominik.big.glsp.uml.uml.elements.use_case.gmodel.UseCaseGModelMapper;
+
+public class UseCaseElementManifest extends BGEMFNodeElementManifest {
+   public UseCaseElementManifest(final BGRepresentationManifest manifest) {
+      super(manifest, Set.of(UMLTypes.USE_CASE));
+   }
+
+   @Override
+   protected void configureElement() {
+      bindGModelMapper(UseCaseGModelMapper.class);
+      bindConfiguration(UseCaseConfiguration.class);
+      bindCreateHandler(UseCaseOperationHandler.class);
+      bindEditLabel(Set.of(NamedElementLabelEditHandler.class));
+      bindPropertyPalette(BGPropertyPaletteContribution.Options.builder()
+         .propertyProviders(Set.of(
+            NamedElementPropertyProvider.class)));
+   }
+}

--- a/server/com.borkdominik.big.glsp.uml/src/main/java/com/borkdominik/big/glsp/uml/uml/elements/use_case/UseCaseOperationHandler.java
+++ b/server/com.borkdominik.big.glsp.uml/src/main/java/com/borkdominik/big/glsp/uml/uml/elements/use_case/UseCaseOperationHandler.java
@@ -1,0 +1,67 @@
+/********************************************************************************
+ * Copyright (c) 2023 borkdominik and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0, or the MIT License which is
+ * available at https://opensource.org/licenses/MIT.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR MIT
+ ********************************************************************************/
+package com.borkdominik.big.glsp.uml.uml.elements.use_case;
+
+import java.util.Set;
+
+import org.eclipse.emf.common.util.Enumerator;
+import org.eclipse.emf.ecore.EObject;
+import org.eclipse.glsp.server.operations.CreateNodeOperation;
+import org.eclipse.glsp.server.types.GLSPServerException;
+import org.eclipse.uml2.uml.Component;
+import org.eclipse.uml2.uml.Package;
+import org.eclipse.uml2.uml.UMLFactory;
+import org.eclipse.uml2.uml.UseCase;
+
+import com.borkdominik.big.glsp.server.core.commands.semantic.BGCreateNodeSemanticCommand;
+import com.borkdominik.big.glsp.server.core.model.BGTypeProvider;
+import com.borkdominik.big.glsp.server.elements.handler.operations.integrations.BGEMFNodeOperationHandler;
+import com.borkdominik.big.glsp.uml.uml.commands.UMLCreateNodeCommand;
+import com.borkdominik.big.glsp.uml.uml.elements.packageable_element.CreatePackagableElementCommand;
+import com.google.inject.Inject;
+import com.google.inject.assistedinject.Assisted;
+
+public class UseCaseOperationHandler extends BGEMFNodeOperationHandler<UseCase, EObject> {
+
+   @Inject
+   public UseCaseOperationHandler(@Assisted final Enumerator representation,
+      @Assisted final Set<BGTypeProvider> elementTypes) {
+      super(representation, elementTypes);
+
+   }
+
+   @SuppressWarnings({ "unchecked", "rawtypes" })
+   @Override
+   protected BGCreateNodeSemanticCommand<UseCase, EObject, ?> createSemanticCommand(
+      final CreateNodeOperation operation,
+      final EObject parent) {
+      if (parent instanceof Package pack) {
+         var argument = CreatePackagableElementCommand.Argument
+            .<UseCase> createPackageableElementArgumentBuilder()
+            .supplier((p) -> UMLFactory.eINSTANCE.createUseCase())
+            .build();
+
+         return (BGCreateNodeSemanticCommand) new CreatePackagableElementCommand<>(
+            commandContext, pack, argument);
+      } else if (parent instanceof Component comp) {
+         var argument = UMLCreateNodeCommand.Argument
+            .<UseCase, Component> createChildArgumentBuilder()
+            .supplier((x) -> x.createOwnedUseCase(null))
+            .build();
+
+         return (BGCreateNodeSemanticCommand) new UMLCreateNodeCommand<>(commandContext, comp, argument);
+      }
+
+      throw new GLSPServerException(
+         String.format("Can not handle parent of type %s", parent.getClass().getSimpleName()));
+   }
+
+}

--- a/server/com.borkdominik.big.glsp.uml/src/main/java/com/borkdominik/big/glsp/uml/uml/elements/use_case/gmodel/GUseCaseBuilder.java
+++ b/server/com.borkdominik.big.glsp.uml/src/main/java/com/borkdominik/big/glsp/uml/uml/elements/use_case/gmodel/GUseCaseBuilder.java
@@ -1,0 +1,56 @@
+/********************************************************************************
+ * Copyright (c) 2023 borkdominik and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0, or the MIT License which is
+ * available at https://opensource.org/licenses/MIT.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR MIT
+ ********************************************************************************/
+package com.borkdominik.big.glsp.uml.uml.elements.use_case.gmodel;
+
+import java.util.List;
+
+import org.eclipse.glsp.graph.GNode;
+import org.eclipse.glsp.graph.util.GConstants;
+import org.eclipse.uml2.uml.UseCase;
+
+import com.borkdominik.big.glsp.server.sdk.cdk.GCModelContext;
+import com.borkdominik.big.glsp.server.sdk.cdk.base.GCProvider;
+import com.borkdominik.big.glsp.server.sdk.cdk.gmodel.GCModelList;
+import com.borkdominik.big.glsp.server.sdk.gmodel.BCCompartmentBuilder;
+import com.borkdominik.big.glsp.server.sdk.gmodel.BCLayoutOptions;
+import com.borkdominik.big.glsp.server.sdk.ui.builder.GCNodeBuilder;
+import com.borkdominik.big.glsp.uml.uml.elements.named_element.GCNamedElement;
+
+public final class GUseCaseBuilder<TOrigin extends UseCase> extends GCNodeBuilder<TOrigin> {
+
+   public GUseCaseBuilder(final GCModelContext context, final TOrigin origin, final String type) {
+      super(context, origin, type);
+   }
+
+   @Override
+   protected GCModelList<?, ?> createRootComponent(final GNode gmodelRoot) {
+      var componentRoot = new GCModelList<>(context, origin,
+         new BCCompartmentBuilder<>(origin, context)
+            .withRootComponentLayout()
+            .addLayoutOptions(new BCLayoutOptions().hAlign(GConstants.HAlign.CENTER))
+            .build());
+
+      componentRoot.addAll(createComponentChildren(gmodelRoot, componentRoot));
+
+      return componentRoot;
+   }
+
+   @Override
+   protected List<GCProvider> createComponentChildren(final GNode gmodelRoot, final GCModelList<?, ?> root) {
+      var namedElementOptions = GCNamedElement.Options.builder()
+         .container(root)
+         .build();
+
+      var name = new GCNamedElement<>(context, origin, namedElementOptions);
+
+      return List.of(name);
+   }
+}

--- a/server/com.borkdominik.big.glsp.uml/src/main/java/com/borkdominik/big/glsp/uml/uml/elements/use_case/gmodel/UseCaseGModelMapper.java
+++ b/server/com.borkdominik.big.glsp.uml/src/main/java/com/borkdominik/big/glsp/uml/uml/elements/use_case/gmodel/UseCaseGModelMapper.java
@@ -1,0 +1,53 @@
+/********************************************************************************
+ * Copyright (c) 2021-2022 borkdominik and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0, or the MIT License which is
+ * available at https://opensource.org/licenses/MIT.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR MIT
+ ********************************************************************************/
+package com.borkdominik.big.glsp.uml.uml.elements.use_case.gmodel;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+
+import org.eclipse.emf.common.util.Enumerator;
+import org.eclipse.glsp.graph.GModelElement;
+import org.eclipse.glsp.graph.GNode;
+import org.eclipse.uml2.uml.UseCase;
+
+import com.borkdominik.big.glsp.server.core.model.BGTypeProvider;
+import com.borkdominik.big.glsp.server.elements.gmodel.BGEMFElementGModelMapper;
+import com.borkdominik.big.glsp.uml.uml.UMLTypes;
+import com.google.inject.Inject;
+import com.google.inject.assistedinject.Assisted;
+
+public final class UseCaseGModelMapper extends BGEMFElementGModelMapper<UseCase, GNode> {
+
+   @Inject
+   public UseCaseGModelMapper(@Assisted final Enumerator representation,
+      @Assisted final Set<BGTypeProvider> elementTypes) {
+      super(representation, elementTypes);
+   }
+
+   @Override
+   public GNode map(final UseCase source) {
+      return new GUseCaseBuilder<>(gcmodelContext, source, UMLTypes.USE_CASE.prefix(representation))
+         .buildGModel();
+   }
+
+   @Override
+   public List<GModelElement> mapSiblings(final UseCase source) {
+      var siblings = new ArrayList<GModelElement>();
+
+      siblings.addAll(mapHandler.handle(source.getIncludes()));
+      siblings.addAll(mapHandler.handle(source.getExtends()));
+      siblings.addAll(mapHandler.handle(source.getGeneralizations()));
+
+      return siblings;
+   }
+
+}

--- a/server/com.borkdominik.big.glsp.uml/src/main/java/com/borkdominik/big/glsp/uml/uml/representation/class_/ClassToolPaletteProvider.java
+++ b/server/com.borkdominik.big.glsp.uml/src/main/java/com/borkdominik/big/glsp/uml/uml/representation/class_/ClassToolPaletteProvider.java
@@ -15,8 +15,8 @@ import java.util.Map;
 
 import org.eclipse.glsp.server.features.toolpalette.PaletteItem;
 
-import com.borkdominik.big.glsp.server.core.features.tool_palette.BGPaletteItemUtil;
 import com.borkdominik.big.glsp.server.core.features.tool_palette.BGBaseToolPaletteProvider;
+import com.borkdominik.big.glsp.server.core.features.tool_palette.BGPaletteItemUtil;
 import com.borkdominik.big.glsp.uml.uml.UMLTypes;
 import com.borkdominik.big.glsp.uml.unotation.Representation;
 
@@ -56,6 +56,8 @@ public final class ClassToolPaletteProvider extends BGBaseToolPaletteProvider {
             "Aggregation",
             "uml-association-shared-icon"),
          BGPaletteItemUtil.edge(UMLTypes.DEPENDENCY.prefix(representation), "Dependency", "uml-dependency-icon"),
+         BGPaletteItemUtil.edge(UMLTypes.ELEMENT_IMPORT.prefix(representation), "Element Import",
+            "uml-package-import-icon"),
          BGPaletteItemUtil.edge(UMLTypes.GENERALIZATION.prefix(representation), "Generalization",
             "uml-generalization-icon"),
          BGPaletteItemUtil.edge(UMLTypes.INTERFACE_REALIZATION.prefix(representation), "Interface Realization",

--- a/server/com.borkdominik.big.glsp.uml/src/main/java/com/borkdominik/big/glsp/uml/uml/representation/class_/UMLClassManifest.java
+++ b/server/com.borkdominik.big.glsp.uml/src/main/java/com/borkdominik/big/glsp/uml/uml/representation/class_/UMLClassManifest.java
@@ -12,14 +12,9 @@ package com.borkdominik.big.glsp.uml.uml.representation.class_;
 
 import org.eclipse.emf.common.util.Enumerator;
 
-import com.borkdominik.big.glsp.server.core.features.direct_editing.BGDirectEditContribution;
 import com.borkdominik.big.glsp.server.core.features.direct_editing.implementations.BGEMFDefaultDirectEditHandler;
-import com.borkdominik.big.glsp.server.core.features.tool_palette.BGToolPaletteContribution;
-import com.borkdominik.big.glsp.server.core.handler.operation.delete.BGDeleteOperationContribution;
 import com.borkdominik.big.glsp.server.core.handler.operation.delete.implementations.BGEMFDefaultDeleteHandler;
-import com.borkdominik.big.glsp.server.core.handler.operation.reconnect_edge.BGReconnectEdgeOperationContribution;
 import com.borkdominik.big.glsp.server.core.manifest.BGRepresentationManifest;
-import com.borkdominik.big.glsp.server.features.property_palette.BGPropertyPaletteContribution;
 import com.borkdominik.big.glsp.uml.uml.customizations.UMLDefaultPropertyPaletteProvider;
 import com.borkdominik.big.glsp.uml.uml.customizations.UMLDefaultReconnectElementHandler;
 import com.borkdominik.big.glsp.uml.uml.elements.abstraction.AbstractionElementManifest;
@@ -55,30 +50,11 @@ public final class UMLClassManifest extends BGRepresentationManifest {
    protected void configure() {
       super.configure();
 
-      install(new BGToolPaletteContribution(BGToolPaletteContribution.Options.builder()
-         .manifest(this)
-         .concrete(ClassToolPaletteProvider.class)
-         .build()));
-
-      install(new BGDeleteOperationContribution(BGDeleteOperationContribution.Options.builder()
-         .manifest(this)
-         .defaultHandler(BGEMFDefaultDeleteHandler.class)
-         .build()));
-
-      install(new BGDirectEditContribution(BGDirectEditContribution.Options.builder()
-         .manifest(this)
-         .defaultDirectEditHandler(BGEMFDefaultDirectEditHandler.class)
-         .build()));
-
-      install(new BGReconnectEdgeOperationContribution(BGReconnectEdgeOperationContribution.Options.builder()
-         .manifest(this)
-         .defaultHandler(UMLDefaultReconnectElementHandler.class)
-         .build()));
-
-      install(new BGPropertyPaletteContribution(BGPropertyPaletteContribution.Options.builder()
-         .manifest(this)
-         .defaultPaletteProvider(UMLDefaultPropertyPaletteProvider.class)
-         .build()));
+      bindToolPalette(ClassToolPaletteProvider.class);
+      bindDefaultDeleteOperation(BGEMFDefaultDeleteHandler.class);
+      bindDefaultDirectEdit(BGEMFDefaultDirectEditHandler.class);
+      bindDefaultReconnectOperation(UMLDefaultReconnectElementHandler.class);
+      bindDefaultPropertyPalette(UMLDefaultPropertyPaletteProvider.class);
 
       install(new ClassElementManifest(this));
       install(new EnumerationElementManifest(this));

--- a/server/com.borkdominik.big.glsp.uml/src/main/java/com/borkdominik/big/glsp/uml/uml/representation/information_flow/InformationFlowToolPaletteProvider.java
+++ b/server/com.borkdominik.big.glsp.uml/src/main/java/com/borkdominik/big/glsp/uml/uml/representation/information_flow/InformationFlowToolPaletteProvider.java
@@ -1,0 +1,47 @@
+/********************************************************************************
+ * Copyright (c) 2023 EclipseSource and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0, or the MIT License which is
+ * available at https://opensource.org/licenses/MIT.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR MIT
+ ********************************************************************************/
+package com.borkdominik.big.glsp.uml.uml.representation.information_flow;
+
+import java.util.List;
+import java.util.Map;
+
+import org.eclipse.glsp.server.features.toolpalette.PaletteItem;
+
+import com.borkdominik.big.glsp.server.core.features.tool_palette.BGBaseToolPaletteProvider;
+import com.borkdominik.big.glsp.server.core.features.tool_palette.BGPaletteItemUtil;
+import com.borkdominik.big.glsp.uml.uml.UMLTypes;
+import com.borkdominik.big.glsp.uml.unotation.Representation;
+
+public class InformationFlowToolPaletteProvider extends BGBaseToolPaletteProvider {
+   public InformationFlowToolPaletteProvider() {
+      super(Representation.INFORMATION_FLOW);
+   }
+
+   @Override
+   public List<PaletteItem> getItems(final Map<String, String> args) {
+      return List.of(containers(), edges());
+   }
+
+   private PaletteItem containers() {
+      var containers = List.of(
+         BGPaletteItemUtil.node(UMLTypes.CLASS.prefix(representation), "Class", "uml-class-icon"),
+         BGPaletteItemUtil.node(UMLTypes.ACTOR.prefix(representation), "Actor", "uml-actor-icon"));
+
+      return PaletteItem.createPaletteGroup("uml.classifier", "Containers", containers, "symbol-property");
+   }
+
+   private PaletteItem edges() {
+      var edges = List.of(BGPaletteItemUtil.edge(UMLTypes.INFORMATION_FLOW.prefix(representation), "Information Flow",
+         "uml-dependency-icon"));
+
+      return PaletteItem.createPaletteGroup("uml.classifier", "Edges", edges, "symbol-property");
+   }
+}

--- a/server/com.borkdominik.big.glsp.uml/src/main/java/com/borkdominik/big/glsp/uml/uml/representation/information_flow/UMLInformationFlowManifest.java
+++ b/server/com.borkdominik.big.glsp.uml/src/main/java/com/borkdominik/big/glsp/uml/uml/representation/information_flow/UMLInformationFlowManifest.java
@@ -1,0 +1,47 @@
+/********************************************************************************
+ * Copyright (c) 2023 EclipseSource and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0, or the MIT License which is
+ * available at https://opensource.org/licenses/MIT.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR MIT
+ ********************************************************************************/
+package com.borkdominik.big.glsp.uml.uml.representation.information_flow;
+
+import org.eclipse.emf.common.util.Enumerator;
+
+import com.borkdominik.big.glsp.server.core.features.direct_editing.implementations.BGEMFDefaultDirectEditHandler;
+import com.borkdominik.big.glsp.server.core.handler.operation.delete.implementations.BGEMFDefaultDeleteHandler;
+import com.borkdominik.big.glsp.server.core.manifest.BGRepresentationManifest;
+import com.borkdominik.big.glsp.uml.uml.customizations.UMLDefaultPropertyPaletteProvider;
+import com.borkdominik.big.glsp.uml.uml.customizations.UMLDefaultReconnectElementHandler;
+import com.borkdominik.big.glsp.uml.uml.elements.actor.ActorElementManifest;
+import com.borkdominik.big.glsp.uml.uml.elements.class_.ClassElementManifest;
+import com.borkdominik.big.glsp.uml.uml.elements.information_flow.InformationFlowElementManifest;
+import com.borkdominik.big.glsp.uml.unotation.Representation;
+
+public class UMLInformationFlowManifest extends BGRepresentationManifest {
+
+   @Override
+   public Enumerator representation() {
+      return Representation.INFORMATION_FLOW;
+   }
+
+   @Override
+   protected void configure() {
+      super.configure();
+
+      bindToolPalette(InformationFlowToolPaletteProvider.class);
+      bindDefaultDeleteOperation(BGEMFDefaultDeleteHandler.class);
+      bindDefaultDirectEdit(BGEMFDefaultDirectEditHandler.class);
+      bindDefaultReconnectOperation(UMLDefaultReconnectElementHandler.class);
+      bindDefaultPropertyPalette(UMLDefaultPropertyPaletteProvider.class);
+
+      install(new ActorElementManifest(this));
+      install(new ClassElementManifest(this));
+
+      install(new InformationFlowElementManifest(this));
+   }
+}

--- a/server/com.borkdominik.big.glsp.uml/src/main/java/com/borkdominik/big/glsp/uml/uml/representation/package_/PackageToolPaletteProvider.java
+++ b/server/com.borkdominik.big.glsp.uml/src/main/java/com/borkdominik/big/glsp/uml/uml/representation/package_/PackageToolPaletteProvider.java
@@ -1,0 +1,56 @@
+/********************************************************************************
+ * Copyright (c) 2023 EclipseSource and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0, or the MIT License which is
+ * available at https://opensource.org/licenses/MIT.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR MIT
+ ********************************************************************************/
+package com.borkdominik.big.glsp.uml.uml.representation.package_;
+
+import java.util.List;
+import java.util.Map;
+
+import org.eclipse.glsp.server.features.toolpalette.PaletteItem;
+
+import com.borkdominik.big.glsp.server.core.features.tool_palette.BGBaseToolPaletteProvider;
+import com.borkdominik.big.glsp.server.core.features.tool_palette.BGPaletteItemUtil;
+import com.borkdominik.big.glsp.uml.uml.UMLTypes;
+import com.borkdominik.big.glsp.uml.unotation.Representation;
+
+public class PackageToolPaletteProvider extends BGBaseToolPaletteProvider {
+   public PackageToolPaletteProvider() {
+      super(Representation.PACKAGE);
+   }
+
+   @Override
+   public List<PaletteItem> getItems(final Map<String, String> args) {
+      return List.of(containers(), relations());
+   }
+
+   private PaletteItem containers() {
+      var containers = List.of(
+         BGPaletteItemUtil.node(UMLTypes.PACKAGE.prefix(representation), "Package",
+            "uml-package-icon"),
+         BGPaletteItemUtil.node(UMLTypes.CLASS.prefix(representation), "Class",
+            "uml-class-icon"));
+      return PaletteItem.createPaletteGroup("uml.classifier", "Container", containers, "symbol-property");
+   }
+
+   private PaletteItem relations() {
+      var relations = List.of(
+         BGPaletteItemUtil.edge(UMLTypes.USAGE.prefix(representation), "Usage", "uml-usage-icon"),
+         BGPaletteItemUtil.edge(UMLTypes.ABSTRACTION.prefix(representation), "Abstraction", "uml-abstraction-icon"),
+         BGPaletteItemUtil.edge(UMLTypes.DEPENDENCY.prefix(representation), "Dependency", "uml-dependency-icon"),
+         BGPaletteItemUtil.edge(UMLTypes.PACKAGE_IMPORT.prefix(representation), "Package Import",
+            "uml-package-import-icon"),
+         BGPaletteItemUtil.edge(UMLTypes.PACKAGE_MERGE.prefix(representation), "Package Merge",
+            "uml-package-merge-icon"),
+         BGPaletteItemUtil.edge(UMLTypes.ELEMENT_IMPORT.prefix(representation), "Element Import",
+            "uml-package-import-icon"));
+
+      return PaletteItem.createPaletteGroup("uml.classifier", "Relation", relations, "symbol-property");
+   }
+}

--- a/server/com.borkdominik.big.glsp.uml/src/main/java/com/borkdominik/big/glsp/uml/uml/representation/package_/UMLPackageManifest.java
+++ b/server/com.borkdominik.big.glsp.uml/src/main/java/com/borkdominik/big/glsp/uml/uml/representation/package_/UMLPackageManifest.java
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2021 borkdominik and others.
+ * Copyright (c) 2023 EclipseSource and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -8,7 +8,7 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR MIT
  ********************************************************************************/
-package com.borkdominik.big.glsp.uml.uml.representation.class_;
+package com.borkdominik.big.glsp.uml.uml.representation.package_;
 
 import org.eclipse.emf.common.util.Enumerator;
 
@@ -18,66 +18,40 @@ import com.borkdominik.big.glsp.server.core.manifest.BGRepresentationManifest;
 import com.borkdominik.big.glsp.uml.uml.customizations.UMLDefaultPropertyPaletteProvider;
 import com.borkdominik.big.glsp.uml.uml.customizations.UMLDefaultReconnectElementHandler;
 import com.borkdominik.big.glsp.uml.uml.elements.abstraction.AbstractionElementManifest;
-import com.borkdominik.big.glsp.uml.uml.elements.association.AssociationElementManifest;
 import com.borkdominik.big.glsp.uml.uml.elements.class_.ClassElementManifest;
-import com.borkdominik.big.glsp.uml.uml.elements.data_type.DataTypeElementManifest;
 import com.borkdominik.big.glsp.uml.uml.elements.dependency.DependencyElementManifest;
 import com.borkdominik.big.glsp.uml.uml.elements.element_import.ElementImportElementManifest;
-import com.borkdominik.big.glsp.uml.uml.elements.enumeration.EnumerationElementManifest;
-import com.borkdominik.big.glsp.uml.uml.elements.enumeration_literal.EnumerationLiteralElementManifest;
-import com.borkdominik.big.glsp.uml.uml.elements.generalization.GeneralizationElementManifest;
-import com.borkdominik.big.glsp.uml.uml.elements.interface_.InterfaceElementManifest;
-import com.borkdominik.big.glsp.uml.uml.elements.interface_realization.InterfaceRealizationElementManifest;
-import com.borkdominik.big.glsp.uml.uml.elements.operation.OperationElementManifest;
 import com.borkdominik.big.glsp.uml.uml.elements.package_.PackageElementManifest;
 import com.borkdominik.big.glsp.uml.uml.elements.package_import.PackageImportElementManifest;
 import com.borkdominik.big.glsp.uml.uml.elements.package_merge.PackageMergeElementManifest;
-import com.borkdominik.big.glsp.uml.uml.elements.parameter.ParameterElementManifest;
-import com.borkdominik.big.glsp.uml.uml.elements.primitive_type.PrimitiveTypeElementManifest;
-import com.borkdominik.big.glsp.uml.uml.elements.property.PropertyElementManifest;
-import com.borkdominik.big.glsp.uml.uml.elements.realization.RealizationElementManifest;
-import com.borkdominik.big.glsp.uml.uml.elements.substitution.SubstitutionElementManifest;
 import com.borkdominik.big.glsp.uml.uml.elements.usage.UsageElementManifest;
 import com.borkdominik.big.glsp.uml.unotation.Representation;
 
-public final class UMLClassManifest extends BGRepresentationManifest {
+public class UMLPackageManifest extends BGRepresentationManifest {
 
    @Override
    public Enumerator representation() {
-      return Representation.CLASS;
+      return Representation.PACKAGE;
    }
 
    @Override
    protected void configure() {
       super.configure();
 
-      bindToolPalette(ClassToolPaletteProvider.class);
+      bindToolPalette(PackageToolPaletteProvider.class);
       bindDefaultDeleteOperation(BGEMFDefaultDeleteHandler.class);
       bindDefaultDirectEdit(BGEMFDefaultDirectEditHandler.class);
       bindDefaultReconnectOperation(UMLDefaultReconnectElementHandler.class);
       bindDefaultPropertyPalette(UMLDefaultPropertyPaletteProvider.class);
 
-      install(new ClassElementManifest(this));
-      install(new EnumerationElementManifest(this));
-      install(new EnumerationLiteralElementManifest(this));
-      install(new DataTypeElementManifest(this));
-      install(new InterfaceElementManifest(this));
-      install(new OperationElementManifest(this));
       install(new PackageElementManifest(this));
-      install(new ParameterElementManifest(this));
-      install(new PrimitiveTypeElementManifest(this));
-      install(new PropertyElementManifest(this));
-
-      install(new AbstractionElementManifest(this));
-      install(new AssociationElementManifest(this));
-      install(new DependencyElementManifest(this));
-      install(new ElementImportElementManifest(this));
-      install(new GeneralizationElementManifest(this));
-      install(new InterfaceRealizationElementManifest(this));
       install(new PackageImportElementManifest(this));
       install(new PackageMergeElementManifest(this));
-      install(new RealizationElementManifest(this));
-      install(new SubstitutionElementManifest(this));
+      install(new ElementImportElementManifest(this));
+
+      install(new ClassElementManifest(this));
+      install(new DependencyElementManifest(this));
+      install(new AbstractionElementManifest(this));
       install(new UsageElementManifest(this));
    }
 }

--- a/server/com.borkdominik.big.glsp.uml/src/main/java/com/borkdominik/big/glsp/uml/uml/representation/use_case/UMLUseCaseManifest.java
+++ b/server/com.borkdominik.big.glsp.uml/src/main/java/com/borkdominik/big/glsp/uml/uml/representation/use_case/UMLUseCaseManifest.java
@@ -1,0 +1,56 @@
+/********************************************************************************
+ * Copyright (c) 2023 EclipseSource and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0, or the MIT License which is
+ * available at https://opensource.org/licenses/MIT.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR MIT
+ ********************************************************************************/
+package com.borkdominik.big.glsp.uml.uml.representation.use_case;
+
+import org.eclipse.emf.common.util.Enumerator;
+
+import com.borkdominik.big.glsp.server.core.features.direct_editing.implementations.BGEMFDefaultDirectEditHandler;
+import com.borkdominik.big.glsp.server.core.handler.operation.delete.implementations.BGEMFDefaultDeleteHandler;
+import com.borkdominik.big.glsp.server.core.manifest.BGRepresentationManifest;
+import com.borkdominik.big.glsp.uml.uml.customizations.UMLDefaultPropertyPaletteProvider;
+import com.borkdominik.big.glsp.uml.uml.customizations.UMLDefaultReconnectElementHandler;
+import com.borkdominik.big.glsp.uml.uml.elements.actor.ActorElementManifest;
+import com.borkdominik.big.glsp.uml.uml.elements.component.ComponentElementManifest;
+import com.borkdominik.big.glsp.uml.uml.elements.extend.ExtendElementManifest;
+import com.borkdominik.big.glsp.uml.uml.elements.generalization.GeneralizationElementManifest;
+import com.borkdominik.big.glsp.uml.uml.elements.include.IncludeElementManifest;
+import com.borkdominik.big.glsp.uml.uml.elements.use_case.UseCaseElementManifest;
+import com.borkdominik.big.glsp.uml.uml.representation.use_case.elements.association.UseCaseAssociationElementManifest;
+import com.borkdominik.big.glsp.uml.unotation.Representation;
+
+public class UMLUseCaseManifest extends BGRepresentationManifest {
+
+   @Override
+   public Enumerator representation() {
+      return Representation.USE_CASE;
+   }
+
+   @Override
+   protected void configure() {
+      super.configure();
+
+      bindToolPalette(UseCaseToolPaletteProvider.class);
+      bindDefaultDeleteOperation(BGEMFDefaultDeleteHandler.class);
+      bindDefaultDirectEdit(BGEMFDefaultDirectEditHandler.class);
+      bindDefaultReconnectOperation(UMLDefaultReconnectElementHandler.class);
+      bindDefaultPropertyPalette(UMLDefaultPropertyPaletteProvider.class);
+
+      install(new ActorElementManifest(this));
+      install(new UseCaseAssociationElementManifest(this));
+
+      install(new ExtendElementManifest(this));
+      install(new GeneralizationElementManifest(this));
+      install(new IncludeElementManifest(this));
+      install(new ComponentElementManifest(this));
+      install(new UseCaseElementManifest(this));
+
+   }
+}

--- a/server/com.borkdominik.big.glsp.uml/src/main/java/com/borkdominik/big/glsp/uml/uml/representation/use_case/UseCaseToolPaletteProvider.java
+++ b/server/com.borkdominik.big.glsp.uml/src/main/java/com/borkdominik/big/glsp/uml/uml/representation/use_case/UseCaseToolPaletteProvider.java
@@ -1,0 +1,53 @@
+/********************************************************************************
+ * Copyright (c) 2023 EclipseSource and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0, or the MIT License which is
+ * available at https://opensource.org/licenses/MIT.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR MIT
+ ********************************************************************************/
+package com.borkdominik.big.glsp.uml.uml.representation.use_case;
+
+import java.util.List;
+import java.util.Map;
+
+import org.eclipse.glsp.server.features.toolpalette.PaletteItem;
+
+import com.borkdominik.big.glsp.server.core.features.tool_palette.BGBaseToolPaletteProvider;
+import com.borkdominik.big.glsp.server.core.features.tool_palette.BGPaletteItemUtil;
+import com.borkdominik.big.glsp.uml.uml.UMLTypes;
+import com.borkdominik.big.glsp.uml.unotation.Representation;
+
+public class UseCaseToolPaletteProvider extends BGBaseToolPaletteProvider {
+   public UseCaseToolPaletteProvider() {
+      super(Representation.USE_CASE);
+   }
+
+   @Override
+   public List<PaletteItem> getItems(final Map<String, String> args) {
+      return List.of(containers(), relations());
+   }
+
+   protected PaletteItem containers() {
+      var containers = List.of(
+         BGPaletteItemUtil.node(UMLTypes.USE_CASE.prefix(representation), "Usecase", "uml-use-case-icon"),
+         BGPaletteItemUtil.node(UMLTypes.ACTOR.prefix(representation), "Actor", "uml-actor-icon"),
+         BGPaletteItemUtil.node(UMLTypes.COMPONENT.prefix(representation), "Subject", "uml-component-icon"));
+
+      return PaletteItem.createPaletteGroup("uml.classifier", "Container", containers, "symbol-property");
+   }
+
+   protected PaletteItem relations() {
+      var relations = List.of(
+         BGPaletteItemUtil.edge(UMLTypes.INCLUDE.prefix(representation), "Include", "uml-include-icon"),
+         BGPaletteItemUtil.edge(UMLTypes.ASSOCIATION.prefix(representation), "Association",
+            "uml-association-none-icon"),
+         BGPaletteItemUtil.edge(UMLTypes.GENERALIZATION.prefix(representation), "Generalization",
+            "uml-generalization-icon"),
+         BGPaletteItemUtil.edge(UMLTypes.EXTEND.prefix(representation), "Extend", "uml-extend-icon"));
+
+      return PaletteItem.createPaletteGroup("uml.classifier", "Relation", relations, "symbol-property");
+   }
+}

--- a/server/com.borkdominik.big.glsp.uml/src/main/java/com/borkdominik/big/glsp/uml/uml/representation/use_case/elements/association/UseCaseAssociationElementManifest.java
+++ b/server/com.borkdominik.big.glsp.uml/src/main/java/com/borkdominik/big/glsp/uml/uml/representation/use_case/elements/association/UseCaseAssociationElementManifest.java
@@ -1,0 +1,27 @@
+/********************************************************************************
+ * Copyright (c) 2023 borkdominik and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0, or the MIT License which is
+ * available at https://opensource.org/licenses/MIT.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR MIT
+ ********************************************************************************/
+package com.borkdominik.big.glsp.uml.uml.representation.use_case.elements.association;
+
+import com.borkdominik.big.glsp.server.core.manifest.BGRepresentationManifest;
+import com.borkdominik.big.glsp.uml.uml.elements.association.AssociationElementManifest;
+
+public class UseCaseAssociationElementManifest extends AssociationElementManifest {
+   public UseCaseAssociationElementManifest(final BGRepresentationManifest manifest) {
+      super(manifest);
+   }
+
+   @Override
+   protected void configureElement() {
+      super.configureElement();
+
+      bindGModelMapper(UseCaseAssociationGModelMapper.class);
+   }
+}

--- a/server/com.borkdominik.big.glsp.uml/src/main/java/com/borkdominik/big/glsp/uml/uml/representation/use_case/elements/association/UseCaseAssociationGModelMapper.java
+++ b/server/com.borkdominik.big.glsp.uml/src/main/java/com/borkdominik/big/glsp/uml/uml/representation/use_case/elements/association/UseCaseAssociationGModelMapper.java
@@ -1,0 +1,39 @@
+/********************************************************************************
+ * Copyright (c) 2021 borkdominik and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0, or the MIT License which is
+ * available at https://opensource.org/licenses/MIT.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR MIT
+ ********************************************************************************/
+package com.borkdominik.big.glsp.uml.uml.representation.use_case.elements.association;
+
+import java.util.Set;
+
+import org.eclipse.emf.common.util.Enumerator;
+import org.eclipse.glsp.graph.GEdge;
+import org.eclipse.uml2.uml.Association;
+
+import com.borkdominik.big.glsp.server.core.model.BGTypeProvider;
+import com.borkdominik.big.glsp.uml.uml.UMLTypes;
+import com.borkdominik.big.glsp.uml.uml.elements.association.gmodel.AssociationGModelMapper;
+import com.google.inject.Inject;
+import com.google.inject.assistedinject.Assisted;
+
+public class UseCaseAssociationGModelMapper extends AssociationGModelMapper {
+
+   @Inject
+   public UseCaseAssociationGModelMapper(@Assisted final Enumerator representation,
+      @Assisted final Set<BGTypeProvider> elementTypes) {
+      super(representation, elementTypes);
+   }
+
+   @Override
+   public GEdge map(final Association source) {
+      return new UseCaseGAssociationBuilder<>(gcmodelContext, source, UMLTypes.ASSOCIATION.prefix(representation))
+         .buildGModel();
+   }
+
+}

--- a/server/com.borkdominik.big.glsp.uml/src/main/java/com/borkdominik/big/glsp/uml/uml/representation/use_case/elements/association/UseCaseGAssociationBuilder.java
+++ b/server/com.borkdominik.big.glsp.uml/src/main/java/com/borkdominik/big/glsp/uml/uml/representation/use_case/elements/association/UseCaseGAssociationBuilder.java
@@ -1,0 +1,34 @@
+/********************************************************************************
+ * Copyright (c) 2023 borkdominik and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0, or the MIT License which is
+ * available at https://opensource.org/licenses/MIT.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR MIT
+ ********************************************************************************/
+package com.borkdominik.big.glsp.uml.uml.representation.use_case.elements.association;
+
+import java.util.List;
+
+import org.eclipse.glsp.graph.GEdge;
+import org.eclipse.uml2.uml.Association;
+
+import com.borkdominik.big.glsp.server.sdk.cdk.GCModelContext;
+import com.borkdominik.big.glsp.server.sdk.cdk.base.GCProvider;
+import com.borkdominik.big.glsp.server.sdk.cdk.gmodel.GCModelList;
+import com.borkdominik.big.glsp.uml.uml.elements.association.gmodel.GAssociationBuilder;
+
+public class UseCaseGAssociationBuilder<TOrigin extends Association> extends GAssociationBuilder<TOrigin> {
+
+   public UseCaseGAssociationBuilder(final GCModelContext context, final TOrigin origin, final String type) {
+      super(context, origin, type);
+   }
+
+   @Override
+   protected List<GCProvider> createComponentChildren(final GEdge gmodelRoot, final GCModelList<?, ?> componentRoot) {
+      return List.of(createName(componentRoot));
+   }
+
+}

--- a/server/com.borkdominik.big.glsp.uml/src/main/java/com/borkdominik/big/glsp/uml/uml/utils/element/ElementImportPropertyPaletteUtils.java
+++ b/server/com.borkdominik.big.glsp.uml/src/main/java/com/borkdominik/big/glsp/uml/uml/utils/element/ElementImportPropertyPaletteUtils.java
@@ -26,11 +26,13 @@ public class ElementImportPropertyPaletteUtils {
       final EMFIdGenerator idGenerator) {
       var references = packageImports.stream()
          .map(v -> {
-            var label = String.format("<Element Import> %s", v.getImportedElement().getName());
+            var p = v.getImportedElement();
+            var label = String.format("<Element Import> %s", p.getName());
             return ElementReferencePropertyItem.Reference.builder()
-               .elementId(idGenerator.getOrCreateId(v))
+               .elementId(idGenerator.getOrCreateId(p))
                .label(label).name(
-               v.getImportedElement().getName()).build();
+                  p.getName())
+               .build();
          })
          .collect(Collectors.toList());
 


### PR DESCRIPTION
Migrates the following diagrams **server-side** - the client didn't require any migration.

## Use Case
1ba0b42c4e8c12877c2837f4440ef441bc918602

## Information Flow
5e9e488db83253adbbf462427ba8853f6582f074

## Package Diagram
793b41f8cae35d975ef8af6132a9a5f45ee747ea

